### PR TITLE
pool: Control host requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,12 +59,13 @@ type Options struct {
 	} `command:"host" description:"Host a vipnode."`
 
 	Pool struct {
-		Bind        string `long:"bind" description:"Address and port to listen on." default:"0.0.0.0:8080"`
-		Store       string `long:"store" description:"Storage driver. (persist|memory)" default:"persist"`
-		DataDir     string `long:"datadir" description:"Path for storing the persistent database."`
-		TLSHost     string `long:"tlshost" description:"Acquire an ACME TLS cert for this host (forces bind to port :443)."`
-		AllowOrigin string `long:"allow-origin" description:"Include Access-Control-Allow-Origin header for CORS."`
-		Contract    struct {
+		Bind            string `long:"bind" description:"Address and port to listen on." default:"0.0.0.0:8080"`
+		Store           string `long:"store" description:"Storage driver. (persist|memory)" default:"persist"`
+		DataDir         string `long:"datadir" description:"Path for storing the persistent database."`
+		TLSHost         string `long:"tlshost" description:"Acquire an ACME TLS cert for this host (forces bind to port :443)."`
+		AllowOrigin     string `long:"allow-origin" description:"Include Access-Control-Allow-Origin header for CORS."`
+		MaxRequestHosts int    `long:"max-request-hosts" description:"Maximum number of hosts a client is allowed to request."`
+		Contract        struct {
 			RPC        string `long:"rpc" description:"Path or URL of an Ethereum RPC provider for payment contract operations. Must match the network of the contract."`
 			Addr       string `long:"address" description:"Deployed contract address, prefixed with network name scheme. (Example: \"rinkeby://0xb2f8987986259facdc539ac1745f7a0b395972b1\")"`
 			KeyStore   string `long:"keystore" description:"Path to encrypted JSON wallet keystore for contract operator. (Password set in KEYSTORE_PASSPHRASE env)"`

--- a/pool.go
+++ b/pool.go
@@ -174,6 +174,7 @@ func runPool(options Options) error {
 	}
 
 	p := pool.New(storeDriver, balanceManager)
+	p.MaxRequestHosts = options.Pool.MaxRequestHosts
 	p.Version = fmt.Sprintf("vipnode/pool/%s", Version)
 	p.ClientMessager = func(nodeID string) string {
 		var buf bytes.Buffer

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -28,7 +28,8 @@ type HostResponse struct {
 
 // ClientRequest is the request type for Client RPC calls.
 type ClientRequest struct {
-	Kind string `json:"kind"`
+	Kind     string `json:"kind"`
+	NumHosts int    `json:"num_hosts,omitempty"` // NumHosts is the number of hosts to request from the pool. (Optional)
 }
 
 // ClientResponse is the response type for Client RPC calls.


### PR DESCRIPTION
- [x] Allow clients to request a specific number of hosts
- [x] Limit max host requests allowed by the pool
- ~~Allow hosts to request peers from pool. This is useful for managing your own fleet of hosts in a private pool, so you can get your hosts to peer each other.~~ This has unexpected challenges, see #18.