### PR TITLE
Replace host/client dichotomy with capability-based behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ fakehost: $(BINARY)
 	$(RUN) -vv host --pool "ws://$(FAKEBIND)" --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)"
 
 fakehostpool: $(BINARY)
-	$(RUN) -vv host --pool ":memory:" --enode="enode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1@[::]:30303?discport=0" --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)"
+	$(RUN) -vv host --pool ":memory:" --enode="enode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1@127.0.0.1:30303?discport=0" --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)"
 
 fakeclient: $(BINARY)
 	$(RUN) -vv client "http://$(FAKEBIND)" --nodekey=./nodekey --rpc "fakenode://85fbed4332ed4329ca2283f26606618815ae83a870c523bb99b0b2e9dfe5af3b4699c2830ecdeb67519d62362db44aa5a8cafee523e3ab8c76aeef1016f424a4?fakepeers=$(FAKEPEERS)"

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ fakehostpool: $(BINARY)
 fakeclient: $(BINARY)
 	$(RUN) -vv client "http://$(FAKEBIND)" --nodekey=./nodekey --rpc "fakenode://85fbed4332ed4329ca2283f26606618815ae83a870c523bb99b0b2e9dfe5af3b4699c2830ecdeb67519d62362db44aa5a8cafee523e3ab8c76aeef1016f424a4?fakepeers=$(FAKEPEERS)"
 
+poolstatus:
+	@curl -s "http://$(FAKEBIND)" -H 'Origin: http://localhost:3030/status' --data-binary '{"id":1,"method":"pool_status"}'
+
 release:
 	GOOS=linux GOARCH=amd64 LDFLAGS=$(LDFLAGS) ./build_release "$(PKG)" README.md LICENSE
 	GOOS=linux GOARCH=386 LDFLAGS=$(LDFLAGS) ./build_release "$(PKG)" README.md LICENSE

--- a/client.go
+++ b/client.go
@@ -37,6 +37,7 @@ func runClient(options Options) error {
 
 	errChan := make(chan error)
 	c := client.New(remoteNode)
+	c.Version = fmt.Sprintf("vipnode/client/%s", Version)
 	c.PoolMessageCallback = func(msg string) {
 		logger.Alertf("Message from pool: %s", msg)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -106,12 +106,7 @@ func (c *Client) updatePeers(ctx context.Context, p pool.Pool) error {
 	if err != nil {
 		return err
 	}
-	peerIDs := make([]string, 0, len(peers))
-	for _, p := range peers {
-		peerIDs = append(peerIDs, p.ID)
-	}
-
-	update, err := p.Update(ctx, pool.UpdateRequest{Peers: peerIDs})
+	update, err := p.Update(ctx, pool.UpdateRequest{PeerInfo: peers})
 	if err != nil {
 		return err
 	}
@@ -124,9 +119,9 @@ func (c *Client) updatePeers(ctx context.Context, p pool.Pool) error {
 		// tracking their host. That means the client is getting a free ride
 		// and it's up to the host to kick the client when the host deems
 		// necessary.
-		logger.Printf("Sent update: %d peers connected, %d expired in pool. Pool response: %s", len(peerIDs), len(update.InvalidPeers), update.Balance.String())
+		logger.Printf("Sent update: %d peers connected, %d expired in pool. Pool response: %s", len(peers), len(update.InvalidPeers), update.Balance.String())
 	} else {
-		logger.Printf("Sent update: %d peers connected. Pool response: %s", len(peerIDs), update.Balance.String())
+		logger.Printf("Sent update: %d peers connected. Pool response: %s", len(peers), update.Balance.String())
 	}
 
 	return nil

--- a/ethnode/geth.go
+++ b/ethnode/geth.go
@@ -20,11 +20,16 @@ type codedError interface {
 var _ EthNode = &gethNode{}
 
 type gethNode struct {
+	agent  UserAgent
 	client *rpc.Client
 }
 
 func (n *gethNode) ContractBackend() bind.ContractBackend {
 	return ethclient.NewClient(n.client)
+}
+
+func (n *gethNode) UserAgent() UserAgent {
+	return n.agent
 }
 
 func (n *gethNode) Kind() NodeKind {

--- a/ethnode/parity.go
+++ b/ethnode/parity.go
@@ -16,11 +16,16 @@ type parityPeers struct {
 }
 
 type parityNode struct {
+	agent  UserAgent
 	client *rpc.Client
 }
 
 func (n *parityNode) ContractBackend() bind.ContractBackend {
 	return ethclient.NewClient(n.client)
+}
+
+func (n *parityNode) UserAgent() UserAgent {
+	return n.agent
 }
 
 func (n *parityNode) Kind() NodeKind {

--- a/ethnode/parity.go
+++ b/ethnode/parity.go
@@ -55,6 +55,8 @@ func (n *parityNode) Peers(ctx context.Context) ([]PeerInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	// FIXME: Only return connected peers who completed the handshake? In that
+	// case, need to filter by non-empty Protocols
 	return result.Peers, nil
 }
 

--- a/ethnode/parity.go
+++ b/ethnode/parity.go
@@ -55,9 +55,7 @@ func (n *parityNode) Peers(ctx context.Context) ([]PeerInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	// FIXME: Only return connected peers who completed the handshake? In that
-	// case, need to filter by non-empty Protocols
-	return result.Peers, nil
+	return filterActivePeers(result.Peers), nil
 }
 
 func (n *parityNode) Enode(ctx context.Context) (string, error) {
@@ -74,4 +72,19 @@ func (n *parityNode) BlockNumber(ctx context.Context) (uint64, error) {
 		return 0, err
 	}
 	return strconv.ParseUint(result, 0, 64)
+}
+
+// filterActivePeers filters out any peers that have not completed the
+// handshake yet. In Parity, these are peers without any specified Protocols.
+func filterActivePeers(peers []PeerInfo) []PeerInfo {
+	if len(peers) == 0 {
+		return peers
+	}
+	activePeers := make([]PeerInfo, 0, len(peers))
+	for _, peer := range peers {
+		if len(peer.Protocols) > 0 {
+			activePeers = append(activePeers, peer)
+		}
+	}
+	return activePeers
 }

--- a/ethnode/parity_test.go
+++ b/ethnode/parity_test.go
@@ -1,0 +1,75 @@
+package ethnode
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestParityParsePeerInfo(t *testing.T) {
+	// Some examples of parity_netPeers output
+	testcases := []struct {
+		input []byte
+		want  parityPeers
+	}{
+		{
+			input: []byte(`{
+				"active":0,
+				"connected":1,
+				"max":25,
+				"peers":[
+				  {
+				    "caps":[
+				      "eth/62",
+				      "eth/63",
+				      "par/1",
+				      "par/2",
+				      "pip/1"
+				    ],
+				    "id":"a117e71696a740f2d0e5427fed5fa0ab1f343799aa873b46c361d405e9b3319689b26867e9b76921b0714ad79470d374ae4ef15f28ad4fe521de4c4f3ce702bc",
+				    "name":"Parity/v1.8.0-beta-9882902-20171015/x86_64-linux-gnu/rustc1.21.0",
+				    "network":{
+				      "localAddress":"172.18.0.2:41980",
+				      "remoteAddress":"172.18.0.3:30303"
+				    },
+				    "protocols":{
+				      "eth":{},
+				      "pip":{}
+				    }
+				  }
+				]
+			}`),
+			want: parityPeers{
+				Peers: []PeerInfo{
+					{
+						ID:   "a117e71696a740f2d0e5427fed5fa0ab1f343799aa873b46c361d405e9b3319689b26867e9b76921b0714ad79470d374ae4ef15f28ad4fe521de4c4f3ce702bc",
+						Name: "Parity/v1.8.0-beta-9882902-20171015/x86_64-linux-gnu/rustc1.21.0",
+						Caps: []string{"eth/62", "eth/63", "par/1", "par/2", "pip/1"},
+						Network: struct {
+							LocalAddress  string `json:"localAddress"`
+							RemoteAddress string `json:"remoteAddress"`
+						}{"172.18.0.2:41980", "172.18.0.3:30303"},
+						Protocols: map[string]json.RawMessage{
+							"eth": json.RawMessage("{}"),
+							"pip": json.RawMessage("{}"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testcases {
+		var result parityPeers
+		err := json.Unmarshal(tc.input, &result)
+		if err != nil {
+			t.Errorf("[case %d] unexpected error for testcase: %s", i, err)
+			continue
+		}
+		// Clear protocol values for comparison
+		if !reflect.DeepEqual(result, tc.want) {
+			t.Errorf("[case %d] wrong agent values:\n  got: %+v;\n want: %+v", i, result, tc.want)
+		}
+	}
+
+}

--- a/ethnode/parity_test.go
+++ b/ethnode/parity_test.go
@@ -57,6 +57,36 @@ func TestParityParsePeerInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			input: []byte(`{
+				"peers":[
+				  {
+				    "caps":["foo"],
+				    "id":"someid",
+				    "name":"somename",
+				    "protocols":{}
+				  },
+				  {
+				    "caps":["bar"],
+				    "id":"anotherid",
+				    "name":"anothername",
+				    "protocols":{"bar": "baz"}
+				  }
+				]
+			}`),
+			want: parityPeers{
+				Peers: []PeerInfo{
+					{
+						ID:   "anotherid",
+						Name: "anothername",
+						Caps: []string{"bar"},
+						Protocols: map[string]json.RawMessage{
+							"bar": json.RawMessage(`"baz"`),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testcases {
@@ -66,7 +96,7 @@ func TestParityParsePeerInfo(t *testing.T) {
 			t.Errorf("[case %d] unexpected error for testcase: %s", i, err)
 			continue
 		}
-		// Clear protocol values for comparison
+		result.Peers = filterActivePeers(result.Peers)
 		if !reflect.DeepEqual(result, tc.want) {
 			t.Errorf("[case %d] wrong agent values:\n  got: %+v;\n want: %+v", i, result, tc.want)
 		}

--- a/ethnode/rpc.go
+++ b/ethnode/rpc.go
@@ -2,6 +2,7 @@ package ethnode
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"strings"
 
@@ -134,8 +135,14 @@ func DetectClient(client *rpc.Client) (*UserAgent, error) {
 
 // PeerInfo stores the node ID and client metadata about a peer.
 type PeerInfo struct {
-	ID   string `json:"id"`   // Unique node identifier (also the encryption pubkey)
-	Name string `json:"name"` // Name of the node, including client type, version, OS, custom data
+	ID        string                     `json:"id"`        // Unique node identifier (also the encryption pubkey)
+	Name      string                     `json:"name"`      // Name of the node, including client type, version, OS, custom data
+	Caps      []string                   `json:"caps"`      // Capabilities the node is advertising.
+	Protocols map[string]json.RawMessage `json:"protocols"` // Sub-protocol specific metadata fields
+	Network   struct {
+		LocalAddress  string `json:"localAddress"`  // Local endpoint of the TCP data connection
+		RemoteAddress string `json:"remoteAddress"` // Remote endpoint of the TCP data connection
+	} `json:"network"`
 }
 
 // EthNode is the normalized interface between different kinds of nodes.

--- a/ethnode/rpc.go
+++ b/ethnode/rpc.go
@@ -19,6 +19,17 @@ const (
 	Parity
 )
 
+func ParseNodeKind(s string) NodeKind {
+	switch strings.ToLower(s) {
+	case "geth":
+		return Geth
+	case "parity":
+		return Parity
+	default:
+		return Unknown
+	}
+}
+
 type NetworkID int
 
 const (
@@ -63,13 +74,13 @@ func (n NodeKind) String() string {
 
 // UserAgent is the metadata about node client.
 type UserAgent struct {
-	Version     string // Result of web3_clientVersion
-	EthProtocol string // Result of eth_protocolVersion
+	Version     string `json:"version"`      // Result of web3_clientVersion
+	EthProtocol string `json:"eth_protocol"` // Result of eth_protocolVersion
 
 	// Parsed/derived values
-	Kind       NodeKind  // Node implementation
-	Network    NetworkID // Network ID
-	IsFullNode bool      // Is this a full node? (or a light client?)
+	Kind       NodeKind  `json:"kind"`         // Node implementation
+	Network    NetworkID `json:"network"`      // Network ID
+	IsFullNode bool      `json:"is_full_node"` // Is this a full node? (or a light client?)
 }
 
 // ParseUserAgent takes string values as output from the web3 RPC for
@@ -139,7 +150,9 @@ type PeerInfo struct {
 	Name      string                     `json:"name"`      // Name of the node, including client type, version, OS, custom data
 	Caps      []string                   `json:"caps"`      // Capabilities the node is advertising.
 	Protocols map[string]json.RawMessage `json:"protocols"` // Sub-protocol specific metadata fields
-	Network   struct {
+
+	// FIXME: Do we want to include node-local network address state? Or is it unnecessary security leakage?
+	Network struct {
 		LocalAddress  string `json:"localAddress"`  // Local endpoint of the TCP data connection
 		RemoteAddress string `json:"remoteAddress"` // Remote endpoint of the TCP data connection
 	} `json:"network"`

--- a/host.go
+++ b/host.go
@@ -38,6 +38,7 @@ func runHost(options Options) error {
 	}
 
 	h := host.New(remoteNode, options.Host.Payout)
+	h.Version = fmt.Sprintf("vipnode/host/%s", Version)
 	if options.Host.NodeURI != "" {
 		if err := matchEnode(options.Host.NodeURI, nodeID); err != nil {
 			return err

--- a/host/host.go
+++ b/host/host.go
@@ -72,22 +72,18 @@ func (h *Host) updatePeers(ctx context.Context, p pool.Pool) error {
 	if err != nil {
 		return err
 	}
-	peerUpdate := make([]string, 0, len(peers))
-	for _, peer := range peers {
-		peerUpdate = append(peerUpdate, peer.ID)
-	}
 	update, err := p.Update(ctx, pool.UpdateRequest{
-		Peers:       peerUpdate,
+		PeerInfo:    peers,
 		BlockNumber: block,
 	})
 	if err != nil {
 		return err
 	}
 	if len(update.InvalidPeers) == 0 {
-		logger.Printf("Sent update: %d peers. Pool response: %s", len(peerUpdate), update.Balance.String())
+		logger.Printf("Sent update: %d peers. Pool response: %s", len(peers), update.Balance.String())
 		return nil
 	}
-	logger.Printf("Sent update: %d peers. Pool response: Disconnect from %d invalid peers, %s", len(peerUpdate), len(update.InvalidPeers), update.Balance.String())
+	logger.Printf("Sent update: %d peers. Pool response: Disconnect from %d invalid peers, %s", len(peers), len(update.InvalidPeers), update.Balance.String())
 	for _, peerID := range update.InvalidPeers {
 		// FIXME: Are there recoverable errors here?
 		if err := h.node.RemoveTrustedPeer(ctx, peerID); err != nil {

--- a/host/host.go
+++ b/host/host.go
@@ -21,10 +21,11 @@ type client struct {
 
 func New(node ethnode.EthNode, payout string) *Host {
 	return &Host{
-		node:   node,
-		payout: payout,
-		stopCh: make(chan struct{}),
-		waitCh: make(chan error, 1),
+		Version: "dev",
+		node:    node,
+		payout:  payout,
+		stopCh:  make(chan struct{}),
+		waitCh:  make(chan error, 1),
 	}
 }
 
@@ -40,6 +41,9 @@ type Host struct {
 	// we can provide an override if there is a non-standard port or if the
 	// node runs on a different IP from the vipnode agent.
 	NodeURI string
+
+	// Version is the version of the vipnode agent that the host is running.
+	Version string
 
 	node   ethnode.EthNode
 	payout string
@@ -120,12 +124,13 @@ func (h *Host) Start(p pool.Pool) error {
 	}
 	logger.Printf("Connected to local node: %s", enode)
 
-	hostReq := pool.HostRequest{
-		Kind:    h.node.Kind().String(),
-		Payout:  h.payout,
-		NodeURI: h.NodeURI,
+	connectReq := pool.ConnectRequest{
+		Payout:         h.payout,
+		NodeURI:        h.NodeURI,
+		VipnodeVersion: h.Version,
+		NodeInfo:       h.node.UserAgent(),
 	}
-	resp, err := p.Host(startCtx, hostReq)
+	resp, err := p.Connect(startCtx, connectReq)
 	if err != nil {
 		return err
 	}

--- a/internal/fakecluster/fakecluster.go
+++ b/internal/fakecluster/fakecluster.go
@@ -118,6 +118,9 @@ func (c *Cluster) Close() error {
 		client.Stop()
 	}
 	for _, host := range c.Hosts {
+		if err := c.Pool.CloseRemote(host.In); err != nil {
+			errors = append(errors, err)
+		}
 		if err := host.Wait(); err != nil {
 			errors = append(errors, err)
 		}

--- a/internal/fakenode/fakenode.go
+++ b/internal/fakenode/fakenode.go
@@ -2,6 +2,7 @@ package fakenode
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 
@@ -59,7 +60,11 @@ func (n *FakeNode) ConnectPeer(ctx context.Context, nodeURI string) error {
 		return err
 	}
 	n.FakePeers = append(n.FakePeers, ethnode.PeerInfo{
-		ID: uri.User.Username(),
+		ID:   uri.User.Username(),
+		Caps: []string{"fake/1", "eth/62", "eth/63", "les/2"},
+		Protocols: map[string]json.RawMessage{
+			"fake": json.RawMessage("{}"),
+		},
 	})
 	return nil
 }

--- a/internal/fakenode/fakenode.go
+++ b/internal/fakenode/fakenode.go
@@ -24,9 +24,10 @@ func Call(method string, args ...interface{}) call {
 
 func Node(nodeID string) *FakeNode {
 	return &FakeNode{
-		NodeKind: ethnode.Geth,
-		NodeID:   nodeID,
-		Calls:    Calls{},
+		NodeKind:   ethnode.Geth,
+		NodeID:     nodeID,
+		Calls:      Calls{},
+		IsFullNode: true,
 	}
 }
 
@@ -37,12 +38,21 @@ type FakeNode struct {
 	Calls           Calls
 	FakePeers       []ethnode.PeerInfo
 	FakeBlockNumber uint64
+	IsFullNode      bool
 }
 
 func (n *FakeNode) ContractBackend() bind.ContractBackend {
 	return &ethclient.Client{}
 }
 
+func (n *FakeNode) UserAgent() ethnode.UserAgent {
+	return ethnode.UserAgent{
+		Version:    "Geth/Fakenode/Go-tests",
+		Network:    1,
+		IsFullNode: n.IsFullNode,
+		Kind:       n.NodeKind,
+	}
+}
 func (n *FakeNode) Kind() ethnode.NodeKind                    { return n.NodeKind }
 func (n *FakeNode) Enode(ctx context.Context) (string, error) { return n.NodeID, nil }
 func (n *FakeNode) AddTrustedPeer(ctx context.Context, nodeID string) error {

--- a/jsonrpc2/remote.go
+++ b/jsonrpc2/remote.go
@@ -13,6 +13,8 @@ import (
 
 // ServePipe sets up symmetric server/clients over a net.Pipe() and starts
 // both in goroutines. Useful for testing. Services still need to be registered.
+// FIXME: This is a testing helper, ideally we want to get rid of it. It leaks
+// goroutines by design.
 func ServePipe() (*Remote, *Remote) {
 	c1, c2 := net.Pipe()
 	client := Remote{

--- a/jsonrpc2/server_test.go
+++ b/jsonrpc2/server_test.go
@@ -9,7 +9,7 @@ import (
 func TestServer(t *testing.T) {
 	service := &FruitService{}
 	s := Server{}
-	if err := s.Register("foo_", service); err != nil {
+	if err := s.Register("foo_", service, "apple", "banana"); err != nil {
 		t.Error(err)
 	}
 
@@ -41,5 +41,20 @@ func TestServer(t *testing.T) {
 
 	if string(resp.Response.Result) != "null" {
 		t.Errorf("unexpected result: %q", resp.Result)
+	}
+
+	resp = s.Handle(context.Background(), &Message{
+		ID:      json.RawMessage([]byte("3")),
+		Version: Version,
+		Request: &Request{
+			Method: "foo_cherry",
+		},
+	})
+	if resp.Error == nil {
+		t.Errorf("expected error, got: %q", resp)
+	}
+
+	if resp.Error.Message != "method not found: foo_cherry" {
+		t.Errorf("unexpected error message: %q", resp.Error)
 	}
 }

--- a/jsonrpc2/types.go
+++ b/jsonrpc2/types.go
@@ -2,6 +2,7 @@ package jsonrpc2
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 const Version = "2.0"
@@ -22,6 +23,16 @@ type Message struct {
 	*Response
 	ID      json.RawMessage `json:"id,omitempty"`
 	Version string          `json:"jsonrpc"` // TODO: Replace this with a null-type that encodes to 2.0, like https://go-review.googlesource.com/c/tools/+/136675/1/internal/jsonrpc2/jsonrpc2.go#221
+}
+
+func (m Message) String() string {
+	// This method is here to satisfy vet
+	b, err := json.Marshal(m)
+	if err != nil {
+		// This shouldn't happen. Might even be worth panic'ing?
+		return fmt.Sprintf("failed to marshal %T: %s", m, err)
+	}
+	return string(b)
 }
 
 type Request struct {

--- a/jsonrpc2/types_test.go
+++ b/jsonrpc2/types_test.go
@@ -1,0 +1,15 @@
+package jsonrpc2
+
+import "testing"
+
+func TestMessageFormat(t *testing.T) {
+	msg := &Message{
+		ID:      []byte("42"),
+		Version: "2.0",
+	}
+
+	got, want := msg.String(), `{"id":42,"jsonrpc":"2.0"}`
+	if got != want {
+		t.Errorf("wrong message string formatting:\n  got: %s;\n want: %s", got, want)
+	}
+}

--- a/pool.go
+++ b/pool.go
@@ -191,8 +191,9 @@ func runPool(options Options) error {
 	}
 
 	handler := &server{
-		ws:     &ws.Upgrader{},
-		header: http.Header{},
+		ws:           &ws.Upgrader{},
+		header:       http.Header{},
+		onDisconnect: p.OnDisconnect,
 	}
 	if options.Pool.AllowOrigin != "" {
 		handler.header.Set("Access-Control-Allow-Origin", options.Pool.AllowOrigin)

--- a/pool.go
+++ b/pool.go
@@ -193,7 +193,7 @@ func runPool(options Options) error {
 	handler := &server{
 		ws:           &ws.Upgrader{},
 		header:       http.Header{},
-		onDisconnect: p.OnDisconnect,
+		onDisconnect: p.CloseRemote,
 	}
 	if options.Pool.AllowOrigin != "" {
 		handler.header.Set("Access-Control-Allow-Origin", options.Pool.AllowOrigin)

--- a/pool.go
+++ b/pool.go
@@ -199,7 +199,7 @@ func runPool(options Options) error {
 		handler.header.Set("Access-Control-Allow-Origin", options.Pool.AllowOrigin)
 	}
 
-	if err := handler.Register("vipnode_", p); err != nil {
+	if err := handler.Register("vipnode_", p, "connect", "disconnect", "ping", "update", "client", "host"); err != nil {
 		return err
 	}
 

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -94,7 +94,7 @@ type ClientResponse struct {
 
 // UpdateRequest is the request type for Update RPC calls.
 type UpdateRequest struct {
-	Peers       []string           `json:"peers"` // DEPRECATED
+	Peers       []string           `json:"peers,omitempty"` // DEPRECATED
 	PeerInfo    []ethnode.PeerInfo `json:"peers_info"`
 	BlockNumber uint64             `json:"block_number"`
 }
@@ -126,6 +126,8 @@ type Pool interface {
 	// a list of peers that are no longer corroborated by the pool, and current
 	// balance for the node (if relevant).
 	Update(ctx context.Context, req UpdateRequest) (*UpdateResponse, error)
+
+	// TODO: RequestHosts(ctx context.Context, req RequestHostsRequest) (*RequestHostsRequest, error)
 
 	// Withdraw prompts a request to settle the node's balance.
 	Withdraw(ctx context.Context) error

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -7,16 +7,11 @@ import (
 	"github.com/vipnode/vipnode/pool/store"
 )
 
-// TODO: Add HostRequest.Network and ClientRequest.Network?
-// TODO: Add HostRequest.HostVersion?
-
 // ConnectRequest is a base request done when a vipnode agent connects to a pool.
 // It is common between hosts and clients
 type ConnectRequest struct {
 	// VipnodeVersion is the version string of the vipnode agent
 	VipnodeVersion string `json:"vipnode_version"`
-
-	// XXX: Add Protocols/Capabilities
 
 	// NodeInfo is the metadata of the Ethereum node, includes node kind.
 	NodeInfo ethnode.UserAgent `json:"node_info"`

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -3,16 +3,57 @@ package pool
 import (
 	"context"
 
+	"github.com/vipnode/vipnode/ethnode"
 	"github.com/vipnode/vipnode/pool/store"
 )
 
 // TODO: Add HostRequest.Network and ClientRequest.Network?
 // TODO: Add HostRequest.HostVersion?
 
+// ConnectRequest is a base request done when a vipnode agent connects to a pool.
+// It is common between hosts and clients
+type ConnectRequest struct {
+	// VipnodeVersion is the version string of the vipnode agent
+	VipnodeVersion string `json:"vipnode_version"`
+
+	// XXX: Add Protocols/Capabilities
+
+	// NodeInfo is the metadata of the Ethereum node, includes node kind.
+	NodeInfo ethnode.UserAgent `json:"node_info"`
+
+	// NodeURI is an optional public node URI override, useful if the vipnode
+	// agent runs on a separate IP from the actual node host. Otherwise, the
+	// pool will automatically use the same IP and default port as the host
+	// connecting.
+	NodeURI string `json:"node_uri,omitempty"`
+
+	// NumHosts is the number of hosts to request from the pool. (Optional)
+	NumHosts int `json:"num_hosts,omitempty"`
+
+	// Payout sets the wallet account to register the host credit towards. (Optional)
+	Payout string `json:"payout"`
+}
+
+// ConnectResponse is the response a vipnode agent receives from the pool after
+// the first connection request. It is common between hosts and clients.
+type ConnectResponse struct {
+	// PoolVersion is the version of vipnode-pool that is running.
+	PoolVersion string `json:"pool_version"`
+	// Hosts that have whitelisted the NodeID and are ready for the node to
+	// connect to.
+	Hosts []store.Node `json:"hosts,omitempty"`
+	// Message contains a prompt for the client from the pool, possibly
+	// instructions for interfacing with this pool. For example, a link to the
+	// DApp for adding a balance deposit.
+	Message string `json:"message,omitempty"`
+}
+
 // HostRequest is the request type for Host RPC calls.
+// DEPRECATED: Use ConnectRequest/ConnectResponse
 type HostRequest struct {
 	// Kind is the type of node the host supports: geth, parity
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
+
 	// Payout sets the wallet account to register the host credit towards.
 	Payout string `json:"payout"`
 	// Optional public node URI override, useful if the vipnode agent runs on a
@@ -22,20 +63,26 @@ type HostRequest struct {
 }
 
 // HostResponse is the response type for Host RPC calls.
+// DEPRECATED: Use ConnectRequest/ConnectResponse
 type HostResponse struct {
 	PoolVersion string `json:"pool_version"`
 }
 
 // ClientRequest is the request type for Client RPC calls.
+// DEPRECATED: Use ConnectRequest/ConnectResponse
 type ClientRequest struct {
-	Kind     string `json:"kind"`
-	NumHosts int    `json:"num_hosts,omitempty"` // NumHosts is the number of hosts to request from the pool. (Optional)
+	// Kind is the type of node the host supports: geth, parity
+	Kind string `json:"kind,omitempty"`
+
+	// NumHosts is the number of hosts to request from the pool. (Optional)
+	NumHosts int `json:"num_hosts,omitempty"`
 }
 
 // ClientResponse is the response type for Client RPC calls.
+// DEPRECATED: Use ConnectRequest/ConnectResponse
 type ClientResponse struct {
-	// Hosts that have whitelisted the client NodeID and are ready for the
-	// client to connect.
+	// Hosts that have whitelisted the NodeID and are ready for the node to
+	// connect to.
 	Hosts []store.Node `json:"hosts"`
 	// PoolVersion is the version of vipnode-pool that is running.
 	PoolVersion string `json:"pool_version"`
@@ -47,8 +94,9 @@ type ClientResponse struct {
 
 // UpdateRequest is the request type for Update RPC calls.
 type UpdateRequest struct {
-	Peers       []string `json:"peers"`
-	BlockNumber uint64   `json:"block_number"`
+	Peers       []string           `json:"peers"` // DEPRECATED
+	PeerInfo    []ethnode.PeerInfo `json:"peers_info"`
+	BlockNumber uint64             `json:"block_number"`
 }
 
 // UpdateResponse is the response type for Update RPC calls.
@@ -60,10 +108,15 @@ type UpdateResponse struct {
 // Pool represents a vipnode pool for coordinating between clients and hosts.
 type Pool interface {
 	// Host subscribes a host to receive vipnode_whitelist instructions.
+	// DEREPCATED: Use Connect
 	Host(ctx context.Context, req HostRequest) (*HostResponse, error)
 
 	// Client requests for available hosts to connect to as a client.
+	// DEREPCATED: Use Connect
 	Client(ctx context.Context, req ClientRequest) (*ClientResponse, error)
+
+	// Host subscribes a host to receive vipnode_whitelist instructions.
+	Connect(ctx context.Context, req ConnectRequest) (*ConnectResponse, error)
 
 	// Disconnect stops tracking the connection and billing, will prompt a
 	// disconnect from both ends.

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -115,7 +115,7 @@ type Pool interface {
 	// DEREPCATED: Use Connect
 	Client(ctx context.Context, req ClientRequest) (*ClientResponse, error)
 
-	// Host subscribes a host to receive vipnode_whitelist instructions.
+	// Connect subscribes to the active nodes set.
 	Connect(ctx context.Context, req ConnectRequest) (*ConnectResponse, error)
 
 	// Disconnect stops tracking the connection and billing, will prompt a

--- a/pool/remote.go
+++ b/pool/remote.go
@@ -73,6 +73,26 @@ func (p *RemotePool) Client(ctx context.Context, req ClientRequest) (*ClientResp
 	return &resp, nil
 }
 
+func (p *RemotePool) Connect(ctx context.Context, req ConnectRequest) (*ConnectResponse, error) {
+	signedReq := request.NodeRequest{
+		Method:    "vipnode_connect",
+		NodeID:    p.nodeID,
+		Nonce:     p.getNonce(),
+		ExtraArgs: []interface{}{req},
+	}
+
+	args, err := signedReq.SignedArgs(p.privkey)
+	if err != nil {
+		return nil, err
+	}
+	var resp ConnectResponse
+	if err := p.client.Call(ctx, &resp, signedReq.Method, args...); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 func (p *RemotePool) Disconnect(ctx context.Context) error {
 	signedReq := request.NodeRequest{
 		Method: "vipnode_disconnect",

--- a/pool/service.go
+++ b/pool/service.go
@@ -57,8 +57,8 @@ type VipnodePool struct {
 	remoteNodeLookup map[jsonrpc2.Service]store.NodeID // Reverse lookup
 }
 
-// OnDisconnect is to be called when a remote service is disconnected. It is used to clean up state.
-func (p *VipnodePool) OnDisconnect(remote jsonrpc2.Service) error {
+// CloseRemote is to be called when a remote service is disconnected. It is used to clean up state.
+func (p *VipnodePool) CloseRemote(remote jsonrpc2.Service) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 

--- a/pool/service.go
+++ b/pool/service.go
@@ -406,9 +406,10 @@ func (p *VipnodePool) requestHosts(ctx context.Context, nodeID string, numReques
 
 	if len(errors) > 0 {
 		err = RemoteHostErrors{"vipnode_whitelist", errors}
+		logger.Printf("Request %q hosts: %q (%d hosts found, %d accepted); failures: %s", kind, pretty.Abbrev(nodeID), len(remotes), len(accepted), err)
+	} else {
+		logger.Printf("Request %q hosts: %q (%d hosts found, %d accepted)", kind, pretty.Abbrev(nodeID), len(remotes), len(accepted))
 	}
-
-	logger.Printf("Request hosts from %q: kind=%q (%d hosts found, %d accepted), failures=%s", pretty.Abbrev(nodeID), kind, len(remotes), len(accepted), err)
 
 	if len(accepted) >= 1 {
 		// We're okay returning without an error as long as some hosts succeeded.

--- a/pool/service.go
+++ b/pool/service.go
@@ -57,6 +57,8 @@ type VipnodePool struct {
 	remoteNodeLookup map[jsonrpc2.Service]store.NodeID // Reverse lookup
 }
 
+// TODO: Move CloseRemote and NumRemotes, and remoteHosts etc into a separate struct?
+
 // CloseRemote is to be called when a remote service is disconnected. It is used to clean up state.
 func (p *VipnodePool) CloseRemote(remote jsonrpc2.Service) error {
 	p.mu.Lock()
@@ -72,6 +74,13 @@ func (p *VipnodePool) CloseRemote(remote jsonrpc2.Service) error {
 	delete(p.remoteHosts, nodeID)
 
 	return nil
+}
+
+// NumRemotes returns the number of remote hosts that the pool is currently maintaining.
+func (p *VipnodePool) NumRemotes() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.remoteHosts)
 }
 
 func (p *VipnodePool) verify(sig string, method string, nodeID string, nonce int64, args ...interface{}) error {

--- a/pool/service.go
+++ b/pool/service.go
@@ -297,12 +297,13 @@ func (p *VipnodePool) connect(ctx context.Context, nodeID string, req ConnectReq
 	}
 
 	if isHost {
-		// We only care about publicly-visible nodeURIs for hosts.
+		// Hosts expose a reverse-RPC for vipnode_whitelist.
 		service, err := jsonrpc2.CtxService(ctx)
 		if err != nil {
 			return nil, err
 		}
 
+		// We only care about publicly-visible nodeURIs for hosts.
 		remoteHost := ""
 		if withAddr, ok := service.(interface{ RemoteAddr() string }); ok {
 			remoteHost = (&url.URL{Host: withAddr.RemoteAddr()}).Hostname()

--- a/pool/service.go
+++ b/pool/service.go
@@ -31,6 +31,8 @@ func New(storeDriver store.Store, manager balance.Manager) *VipnodePool {
 		manager = balance.NoBalance{}
 	}
 	return &VipnodePool{
+		Version: "dev",
+
 		Store:            storeDriver,
 		BalanceManager:   manager,
 		remoteHosts:      map[store.NodeID]jsonrpc2.Service{},

--- a/pool/service.go
+++ b/pool/service.go
@@ -285,11 +285,13 @@ func (p *VipnodePool) connect(ctx context.Context, nodeID string, req ConnectReq
 	// get successfully whitelisted, then switched to host status thus bypass
 	// billing?
 	node := store.Node{
-		ID:       store.NodeID(nodeID),
-		Kind:     kind,
-		LastSeen: time.Now(),
-		IsHost:   isHost,
-		Payout:   store.Account(req.Payout),
+		ID:             store.NodeID(nodeID),
+		Kind:           kind,
+		LastSeen:       time.Now(),
+		IsHost:         isHost,
+		Payout:         store.Account(req.Payout),
+		NodeVersion:    req.NodeInfo.Version,
+		VipnodeVersion: req.VipnodeVersion,
 	}
 
 	if isHost {

--- a/pool/staticpool.go
+++ b/pool/staticpool.go
@@ -32,6 +32,10 @@ func (s *StaticPool) Client(ctx context.Context, req ClientRequest) (*ClientResp
 	return &ClientResponse{Hosts: s.Nodes}, nil
 }
 
+func (s *StaticPool) Connect(ctx context.Context, req ConnectRequest) (*ConnectResponse, error) {
+	return &ConnectResponse{Hosts: s.Nodes}, nil
+}
+
 func (s *StaticPool) Disconnect(ctx context.Context) error {
 	return nil
 }

--- a/pool/status/status.go
+++ b/pool/status/status.go
@@ -20,6 +20,9 @@ type Host struct {
 	Kind        string    `json:"kind"`
 	BlockNumber uint64    `json:"block_number"`
 
+	NodeVersion    string `json:"node_version"`
+	VipnodeVersion string `json:"vipnode_version"`
+
 	// TODO: Add peers
 }
 
@@ -33,6 +36,9 @@ func nodeHost(n store.Node) Host {
 		LastSeen:    n.LastSeen,
 		Kind:        n.Kind,
 		BlockNumber: n.BlockNumber,
+
+		NodeVersion:    n.NodeVersion,
+		VipnodeVersion: n.VipnodeVersion,
 	}
 }
 

--- a/pool/store/store.go
+++ b/pool/store/store.go
@@ -63,6 +63,9 @@ type Node struct {
 	IsHost      bool
 	Payout      Account
 	BlockNumber uint64 `json:"block_number"`
+
+	NodeVersion    string `json:"node_version"`
+	VipnodeVersion string `json:"vipnode_version"`
 }
 
 // Stats contains various aggregate stats of the store state, used for

--- a/poolhostclient_test.go
+++ b/poolhostclient_test.go
@@ -174,6 +174,10 @@ func TestPoolHostConnectPeers(t *testing.T) {
 		t.Errorf("wrong number of hosts: got %d; want %d", got, want)
 	}
 
+	if got, want := cluster.Pool.NumRemotes(), 4; got != want {
+		t.Errorf("wrong number of remotes: got %d; want %d", got, want)
+	}
+
 	stats, err := cluster.Pool.Store.Stats()
 	if err != nil {
 		t.Error(err)
@@ -232,5 +236,9 @@ func TestPoolHostConnectPeers(t *testing.T) {
 	err = cluster.Close()
 	if err != nil {
 		t.Error(err)
+	}
+
+	if got, want := cluster.Pool.NumRemotes(), 0; got != want {
+		t.Errorf("wrong number of remotes: got %d; want %d", got, want)
 	}
 }

--- a/poolhostclient_test.go
+++ b/poolhostclient_test.go
@@ -195,7 +195,7 @@ func TestPoolHostConnectPeers(t *testing.T) {
 		hostPool := pool.Remote(host.Out, host.Key)
 
 		if err := host.ConnectPeers(hostPool, numHosts); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 
 		if peers, err := host.Node.Peers(context.Background()); err != nil {


### PR DESCRIPTION
- [x] Rebased on #21 
- [x] Add Pool.Connect RPC
- [x] Deprecated Pool.Client and Pool.Host RPCs, with backports using Pool.Connect
- [x] Existing tests pass
- [x] Change update logic to allow host-to-host participation without host/client conflict. This can either be done by ignoring host-to-host metering, or by applying host-to-host metering and letting it cancel out.
- [x] Add nodes' UserAgent to pool status
- [x] Make sure pool.remoteHosts are released on disconnect. (Not super necessarily part of this PR, but would be good to take another look at it now.)