### PR TITLE
main: Add agent subcommand, deprecated host and client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,13 @@ fakepool: $(BINARY)
 	$(RUN) -vv pool --bind "$(FAKEBIND)" --store="memory" --allow-origin "http://localhost:3000"
 
 fakehost: $(BINARY)
-	$(RUN) -vv agent "ws://$(FAKEBIND)" --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)&fullnode=1"
+	$(RUN) -vv agent "ws://$(FAKEBIND)" --update-interval=10s --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)&fullnode=1"
 
 fakehostpool: $(BINARY)
-	$(RUN) -vv agent ":memory:" --enode="enode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1@127.0.0.1:30303?discport=0" --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)&fullnode=1"
+	$(RUN) -vv agent ":memory:" --update-interval=10s --enode="enode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1@127.0.0.1:30303?discport=0" --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)&fullnode=1"
 
 fakeclient: $(BINARY)
-	$(RUN) -vv agent "http://$(FAKEBIND)" --nodekey=./nodekey --rpc "fakenode://85fbed4332ed4329ca2283f26606618815ae83a870c523bb99b0b2e9dfe5af3b4699c2830ecdeb67519d62362db44aa5a8cafee523e3ab8c76aeef1016f424a4?fakepeers=$(FAKEPEERS)"
+	$(RUN) -vv agent "http://$(FAKEBIND)" --update-interval=10s --nodekey=./nodekey --rpc "fakenode://85fbed4332ed4329ca2283f26606618815ae83a870c523bb99b0b2e9dfe5af3b4699c2830ecdeb67519d62362db44aa5a8cafee523e3ab8c76aeef1016f424a4?fakepeers=$(FAKEPEERS)"
 
 poolstatus:
 	@curl -s "http://$(FAKEBIND)" -H 'Origin: http://localhost:3030/status' --data-binary '{"id":1,"method":"pool_status"}'

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,13 @@ fakepool: $(BINARY)
 	$(RUN) -vv pool --bind "$(FAKEBIND)" --store="memory" --allow-origin "http://localhost:3000"
 
 fakehost: $(BINARY)
-	$(RUN) -vv host --pool "ws://$(FAKEBIND)" --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)"
+	$(RUN) -vv agent "ws://$(FAKEBIND)" --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)&fullnode=1"
 
 fakehostpool: $(BINARY)
-	$(RUN) -vv host --pool ":memory:" --enode="enode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1@127.0.0.1:30303?discport=0" --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)"
+	$(RUN) -vv agent ":memory:" --enode="enode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1@127.0.0.1:30303?discport=0" --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)&fullnode=1"
 
 fakeclient: $(BINARY)
-	$(RUN) -vv client "http://$(FAKEBIND)" --nodekey=./nodekey --rpc "fakenode://85fbed4332ed4329ca2283f26606618815ae83a870c523bb99b0b2e9dfe5af3b4699c2830ecdeb67519d62362db44aa5a8cafee523e3ab8c76aeef1016f424a4?fakepeers=$(FAKEPEERS)"
+	$(RUN) -vv agent "http://$(FAKEBIND)" --nodekey=./nodekey --rpc "fakenode://85fbed4332ed4329ca2283f26606618815ae83a870c523bb99b0b2e9dfe5af3b4699c2830ecdeb67519d62362db44aa5a8cafee523e3ab8c76aeef1016f424a4?fakepeers=$(FAKEPEERS)"
 
 poolstatus:
 	@curl -s "http://$(FAKEBIND)" -H 'Origin: http://localhost:3030/status' --data-binary '{"id":1,"method":"pool_status"}'

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ You can move the `vipnode` binary into your `$PATH` for convenience: `sudo mv vi
 While exploring, try using the `-vv` flag for extra verbose output.
 
 
-### How to connect as a client
+### How to connect as a light client
 
 Clients pay a small fee per minute of being connected to a vipnode host. When you connect to a pool for the first time, you'll get a welcome message with instructions.
 
 1. Run a local geth in light mode, something like:
     `geth --syncmode=light --rpc --nodiscover --verbosity 7`
-2. `vipnode client -vv`
+2. `vipnode agent -vv`
 
 It should automatically find the RPC and nodekey. If it doesn't, it will fail with a useful error message for how to provide those paths.
 
@@ -60,7 +60,7 @@ Hosts earn a small fee per minute of being connected to a vipnode client.
 
 1. Run a local geth in full mode with lightserv enabled, something like:
     `geth --lightserv=60 --rpc`
-2. `vipnode host -vv --payout=$(MYWALLET)`
+2. `vipnode agent -vv --payout=$(MYWALLET)`
 
 
 ## Advanced Details

--- a/agent.go
+++ b/agent.go
@@ -223,7 +223,7 @@ func (runner *agentRunner) Run() error {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
 	go func() {
-		for _ = range sigCh {
+		for range sigCh {
 			logger.Info("Shutting down...")
 			runner.Agent.Stop()
 		}

--- a/agent.go
+++ b/agent.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/signal"
+
+	"github.com/ethereum/go-ethereum/p2p/discv5"
+	"github.com/vipnode/vipnode/agent"
+	"github.com/vipnode/vipnode/jsonrpc2"
+	ws "github.com/vipnode/vipnode/jsonrpc2/ws/gorilla"
+	"github.com/vipnode/vipnode/pool"
+	"github.com/vipnode/vipnode/pool/store/memory"
+)
+
+func runAgent(options Options) error {
+	remoteNode, err := findRPC(options.Agent.RPC)
+	if err != nil {
+		return err
+	}
+
+	// Node key is required for signing requests from the NodeID to avoid forgery.
+	privkey, err := findNodeKey(options.Agent.NodeKey)
+	if err != nil {
+		return ErrExplain{err, "Failed to find node private key. RPC requests are signed by this key to avoid forgery. Use --nodekey to specify the correct path."}
+	}
+	// Confirm that nodeID matches the private key
+	nodeID := discv5.PubkeyID(&privkey.PublicKey).String()
+	remoteEnode, err := remoteNode.Enode(context.Background())
+	if err != nil {
+		return err
+	}
+	if err := matchEnode(remoteEnode, nodeID); err != nil {
+		return err
+	}
+
+	a := &agent.Agent{
+		EthNode: remoteNode,
+		Payout:  options.Agent.Payout,
+		Version: fmt.Sprintf("vipnode/agent/%s", Version),
+	}
+	if options.Agent.NodeURI != "" {
+		if err := matchEnode(options.Agent.NodeURI, nodeID); err != nil {
+			return err
+		}
+		a.NodeURI = options.Agent.NodeURI
+	} else {
+		// This will populate all the fields except the host, which is fine
+		// because the pool will use the connection's ip as the host.
+		a.NodeURI = remoteEnode
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	go func() {
+		for _ = range sigCh {
+			logger.Info("Shutting down...")
+			a.Stop()
+		}
+	}()
+
+	poolURI := options.Agent.Args.Coordinator
+	uri, err := url.Parse(poolURI)
+	if err != nil {
+		return ErrExplain{err, `Failed to parse the pool coordinator URI. It should look something like: "wss://pool.vipnode.org/"`}
+	}
+
+	// If we want, we can connect to another vipnode agent directly, bypassing the need for a pool.
+	if uri.Scheme == "enode" {
+		staticPool := &pool.StaticPool{}
+		if err := staticPool.AddNode(poolURI); err != nil {
+			return err
+		}
+		logger.Infof("Connecting to a static node (bypassing pool): %s", poolURI)
+		if err := a.Start(staticPool); err != nil {
+			return err
+		}
+		return a.Wait()
+	}
+
+	if poolURI == ":memory:" {
+		// Support for in-memory pool. This is primarily for testing.
+		logger.Infof("Starting in-memory vipnode pool.")
+		p := pool.New(memory.New(), nil)
+		p.Version = fmt.Sprintf("vipnode/memory-pool/%s", Version)
+		rpcPool := &jsonrpc2.Local{}
+		if err := rpcPool.Server.Register("vipnode_", p); err != nil {
+			return err
+		}
+		remotePool := pool.Remote(rpcPool, privkey)
+		if err := a.Start(remotePool); err != nil {
+			return err
+		}
+		return a.Wait()
+	}
+
+	errChan := make(chan error)
+
+	// We support multiple kinds of transports for the pool RPC API. Websocket
+	// is preferred, but we allow HTTP for low power scenarios like mobile
+	// devices.
+	var rpcPool jsonrpc2.Service
+	scheme := uri.Scheme
+	if scheme == "" {
+		// No scheme provided, use websockets
+		scheme = "wss"
+	}
+	switch scheme {
+	case "ws", "wss":
+		// Register reverse-directional RPC calls available on the host
+		var reverseService agent.Service = a
+		rpcServer := &jsonrpc2.Server{}
+		if err := rpcServer.RegisterMethod("vipnode_whitelist", reverseService, "Whitelist"); err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), rpcTimeout)
+		poolCodec, err := ws.WebSocketDial(ctx, uri.String())
+		cancel()
+		if err != nil {
+			return ErrExplainRetry{ErrExplain{err, "Failed to connect to the pool RPC API."}}
+		}
+
+		remote := &jsonrpc2.Remote{
+			Server: rpcServer,
+			Client: &jsonrpc2.Client{},
+			Codec:  poolCodec,
+		}
+		go func() {
+			errChan <- remote.Serve()
+		}()
+		rpcPool = remote
+	case "http", "https":
+		if remoteNode.UserAgent().IsFullNode {
+			revisedURI := uri
+			revisedURI.Scheme = "wss"
+			return ErrExplain{
+				errors.New("full node coordination not supported over HTTP"),
+				"Full nodes must connect over the websocket protocol in order to support bidirectional RPC that is required to coordinate host peers. Try using: " + revisedURI.String(),
+			}
+		}
+		rpcPool = &jsonrpc2.HTTPService{
+			Endpoint: uri.String(),
+		}
+	default:
+		return ErrExplain{
+			errors.New("invalid pool coordinator URI scheme"),
+			`Pool coordinator URI must be one of: ws, wss, http, or https. For example: "wss://pool.vipnode.org/"`,
+		}
+	}
+
+	remotePool := pool.Remote(rpcPool, privkey)
+	if err := a.Start(remotePool); err != nil {
+		if jsonrpc2.IsErrorCode(err, jsonrpc2.ErrCodeMethodNotFound, jsonrpc2.ErrCodeInvalidParams) {
+			err = ErrExplain{err, fmt.Sprintf(`Missing a required RPC method. Make sure your vipnode binary is up to date. (Current version: %s)`, Version)}
+		}
+		return err
+	}
+	go func() {
+		errChan <- a.Wait()
+	}()
+
+	return <-errChan
+
+}

--- a/agent.go
+++ b/agent.go
@@ -53,14 +53,17 @@ func (runner *agentRunner) LoadAgent(options Options) error {
 		return err
 	}
 
-	// Node key is required for signing requests from the NodeID to avoid forgery.
-	privkey, err := findNodeKey(options.Agent.NodeKey)
-	if err != nil {
-		return ErrExplain{err, "Failed to find node private key. RPC requests are signed by this key to avoid forgery. Use --nodekey to specify the correct path."}
+	if runner.PrivateKey == nil {
+		// Node key is required for signing requests from the NodeID to avoid forgery.
+		privkey, err := findNodeKey(options.Agent.NodeKey)
+		if err != nil {
+			return ErrExplain{err, "Failed to find node private key. RPC requests are signed by this key to avoid forgery. Use --nodekey to specify the correct path."}
+		}
+		runner.PrivateKey = privkey
 	}
-	runner.PrivateKey = privkey
+
 	// Confirm that nodeID matches the private key
-	nodeID := discv5.PubkeyID(&privkey.PublicKey).String()
+	nodeID := discv5.PubkeyID(&runner.PrivateKey.PublicKey).String()
 	remoteEnode, err := remoteNode.Enode(context.Background())
 	if err != nil {
 		return err

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -50,6 +50,10 @@ type Agent struct {
 	// (Optional)
 	Payout string
 
+	// UpdateInterval is the time between updates sent to the pool. If not set,
+	// then store.KeepaliveInterval is used.
+	UpdateInterval time.Duration
+
 	mu       sync.Mutex
 	started  bool
 	stopCh   chan struct{}
@@ -131,7 +135,12 @@ func (a *Agent) Wait() error {
 }
 
 func (a *Agent) serveUpdates(p pool.Pool) error {
-	ticker := time.Tick(store.KeepaliveInterval)
+	interval := a.UpdateInterval
+	if interval == 0 {
+		interval = store.KeepaliveInterval
+	}
+
+	ticker := time.Tick(interval)
 	for {
 		select {
 		case <-ticker:

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -220,7 +220,7 @@ func (a *Agent) updatePeers(ctx context.Context, p pool.Pool) error {
 		a.BalanceCallback(balance)
 	}
 
-	logger.Printf("Sent update: %d peers. Pool response: %d active, %d invalid peers, %s", len(peers), len(update.ActivePeers), len(update.InvalidPeers), balance.String())
+	logger.Printf("Pool update: peers=%d active=%d invalid=%d block=%d balance=%s", len(peers), len(update.ActivePeers), len(update.InvalidPeers), blockNumber, balance.String())
 
 	if a.BlockNumberCallback != nil {
 		a.BlockNumberCallback(blockNumber, update.LatestBlockNumber)

--- a/agent/errors.go
+++ b/agent/errors.go
@@ -1,0 +1,17 @@
+package agent
+
+import "fmt"
+
+// AgentPoolError is used when the agent fails during a request to a pool.
+type AgentPoolError struct {
+	cause error
+	msg   string
+}
+
+func (err AgentPoolError) Error() string {
+	return fmt.Sprintf("agent error: %s: %s", err.msg, err.cause.Error())
+}
+
+func (err AgentPoolError) Cause() error {
+	return err.cause
+}

--- a/agent_test.go
+++ b/agent_test.go
@@ -54,7 +54,7 @@ func TestAgentRunner(t *testing.T) {
 	hasLogPrefixes(t, &out, len("[agent] 2019/05/27 13:10:00 "), []string{
 		"Connected to local node:",
 		"Registered on pool: Version vipnode/memory-pool/dev",
-		"Sent update: 3 peers. Pool response:",
+		"Pool update: peers=3 active=0 invalid=0 block=0",
 	})
 
 	if gotBlock != expectBlock {

--- a/agent_test.go
+++ b/agent_test.go
@@ -60,7 +60,7 @@ func TestAgentRunner(t *testing.T) {
 	}
 
 	hasLogPrefixes(t, &out, len("[agent] 2019/05/27 13:10:00 "), []string{
-		"Connected to local node:",
+		"Connected to local",
 		"Registered on pool: Version vipnode/memory-pool/dev",
 		"Pool update: peers=3 active=0 invalid=0 block=0",
 	})

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func TestAgentRunner(t *testing.T) {
+	options := Options{}
+	options.Agent.Args.Coordinator = ":memory:"
+	options.Agent.NodeURI = "enode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1@127.0.0.1:30303?discport=0"
+	options.Agent.RPC = "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=3&fullnode=1"
+	options.Agent.UpdateInterval = "60s"
+
+	runner := agentRunner{}
+	if err := runner.LoadAgent(options); err != nil {
+		t.Fatal(err)
+	}
+	if err := runner.LoadPool(options); err != nil {
+		t.Fatal(err)
+	}
+
+	errors := errgroup.Group{}
+	errors.Go(runner.Run)
+
+	runner.Agent.Stop()
+
+	if err := errors.Wait(); err != nil {
+		t.Error("failed to stop cleanly:", err)
+	}
+}

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
 	"testing"
 
+	"github.com/vipnode/vipnode/agent"
+	"github.com/vipnode/vipnode/ethnode"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -13,12 +19,27 @@ func TestAgentRunner(t *testing.T) {
 	options.Agent.RPC = "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=3&fullnode=1"
 	options.Agent.UpdateInterval = "60s"
 
+	var out bytes.Buffer
+	agent.SetLogger(&out)
+	//SetLogger(golog.New(&out, log.Debug))
+
 	runner := agentRunner{}
 	if err := runner.LoadAgent(options); err != nil {
 		t.Fatal(err)
 	}
 	if err := runner.LoadPool(options); err != nil {
 		t.Fatal(err)
+	}
+
+	var gotBlock, expectBlock uint64 = 0, 42
+	runner.pool.BlockNumberProvider = func(_ ethnode.NetworkID) (uint64, error) {
+		return expectBlock, nil
+	}
+	runner.Agent.BlockNumberCallback = func(nodeBlockNumber uint64, poolBlockNumber uint64) {
+		gotBlock = poolBlockNumber
+		if nodeBlockNumber != 0 {
+			t.Errorf("BlockNumberBallback nodeBlockNumber: got %d; want %d", nodeBlockNumber, 0)
+		}
 	}
 
 	errors := errgroup.Group{}
@@ -28,5 +49,38 @@ func TestAgentRunner(t *testing.T) {
 
 	if err := errors.Wait(); err != nil {
 		t.Error("failed to stop cleanly:", err)
+	}
+
+	hasLogPrefixes(t, &out, len("[agent] 2019/05/27 13:10:00 "), []string{
+		"Connected to local node:",
+		"Registered on pool: Version vipnode/memory-pool/dev",
+		"Sent update: 3 peers. Pool response:",
+	})
+
+	if gotBlock != expectBlock {
+		t.Errorf("BlockNumberBallback poolBlockNumber: got %d; want %d", gotBlock, expectBlock)
+	}
+}
+
+func hasLogPrefixes(t *testing.T, out io.Reader, skipChars int, prefixes []string) {
+	t.Helper()
+
+	buf := bufio.NewReader(out)
+	for _, prefix := range prefixes {
+		for {
+			line, err := buf.ReadString('\n')
+			if err == io.EOF {
+				t.Errorf("failed to find log prefix: %q", prefix)
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			line = line[skipChars:]
+			t.Logf("Looking for prefix: %q ?= %q", prefix, line)
+			if strings.HasPrefix(line, prefix) {
+				break
+			}
+		}
 	}
 }

--- a/ethnode/rpc.go
+++ b/ethnode/rpc.go
@@ -113,6 +113,14 @@ type UserAgent struct {
 	IsFullNode bool      `json:"is_full_node"` // Is this a full node? (or a light client?)
 }
 
+// KindType returns the Kind of node it is, suffixed with -full or -light.
+func (ua *UserAgent) KindType() string {
+	if ua.IsFullNode {
+		return ua.Kind.String() + "-full"
+	}
+	return ua.Kind.String() + "-light"
+}
+
 // ParseUserAgent takes string values as output from the web3 RPC for
 // web3_clientVersion, eth_protocolVersion, and net_version. It returns a
 // parsed user agent metadata.

--- a/ethnode/rpc.go
+++ b/ethnode/rpc.go
@@ -30,13 +30,18 @@ func ParseNodeKind(s string) NodeKind {
 	}
 }
 
+// NetworkID represents the Ethereum network chain.
 type NetworkID int
 
 const (
+	UnknownNetwork NetworkID = 0
+
 	Mainnet NetworkID = 1
 	Morden  NetworkID = 2
 	Ropsten NetworkID = 3
 	Rinkeby NetworkID = 4
+	Goerli  NetworkID = 5
+	Kotti   NetworkID = 6
 	Kovan   NetworkID = 42
 )
 
@@ -52,6 +57,10 @@ func (id NetworkID) String() string {
 		return "rinkeby"
 	case Kovan:
 		return "kovan"
+	case Goerli:
+		return "goerli"
+	case Kotti:
+		return "kotti"
 	}
 	return "unknown"
 }
@@ -59,6 +68,27 @@ func (id NetworkID) String() string {
 // Is compares the ID to a network name.
 func (id NetworkID) Is(network string) bool {
 	return id.String() == strings.ToLower(network)
+}
+
+// ParseNetwork takes a network name string and returns a corresponding NetworkID type.
+func ParseNetwork(network string) NetworkID {
+	switch strings.ToLower(network) {
+	case "mainnet":
+		return Mainnet
+	case "morden":
+		return Morden
+	case "ropsten":
+		return Ropsten
+	case "rinkeby":
+		return Rinkeby
+	case "kovan":
+		return Kovan
+	case "goerli":
+		return Goerli
+	case "kotti":
+		return Kotti
+	}
+	return UnknownNetwork
 }
 
 func (n NodeKind) String() string {

--- a/main.go
+++ b/main.go
@@ -262,7 +262,7 @@ func main() {
 	parser := flags.NewParser(&options, flags.Default)
 	parser.Groups()[0].ShortDescription = "vipnode"
 	parser.SubcommandsOptional = true
-	p, err := parser.Parse()
+	p, err := parser.ParseArgs(os.Args[1:])
 	if err != nil {
 		if p == nil {
 			fmt.Println(err)

--- a/main.go
+++ b/main.go
@@ -375,7 +375,7 @@ func (err ErrExplain) Error() string {
 	if cause == nil {
 		cause = errors.New("an error occurred")
 	}
-	return fmt.Sprintf("%s\n -> %s", err.Cause, err.Explanation)
+	return fmt.Sprintf("%s\n -> %s", cause, err.Explanation)
 }
 
 // ErrExplainRetry is the same as ErrExplain except it can be retried

--- a/main.go
+++ b/main.go
@@ -235,7 +235,7 @@ func subcommand(cmd string, options Options) error {
 		} else if err == io.EOF {
 			logger.Warningf("Connection closed, retrying in %s...", waitTime)
 		} else if errRetry, ok := err.(ErrExplainRetry); ok {
-			logger.Warningf("Failed to connect, retrying in %s: %s", waitTime, errRetry.Cause)
+			logger.Warningf("Failed to connect, retrying in %s: %s", waitTime, errRetry)
 		} else if _, ok := err.(net.Error); ok {
 			logger.Warningf("Failed to connect, retrying in %s: %s", waitTime, err)
 		} else if err.Error() == (pool.NoHostNodesError{}).Error() {
@@ -319,7 +319,7 @@ func main() {
 		return
 	}
 
-	cmd := "client"
+	cmd := "agent"
 	if parser.Active != nil {
 		cmd = parser.Active.Name
 	}

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ type Options struct {
 		DataDir         string `long:"datadir" description:"Path for storing the persistent database."`
 		TLSHost         string `long:"tlshost" description:"Acquire an ACME TLS cert for this host (forces bind to port :443)."`
 		AllowOrigin     string `long:"allow-origin" description:"Include Access-Control-Allow-Origin header for CORS."`
+		RestrictNetwork string `long:"restrict-network" description:"Restrict nodes to a single Ethereum network, such as: mainnet, rinkeby, goerli"`
 		MaxRequestHosts int    `long:"max-request-hosts" description:"Maximum number of hosts a node is allowed to request."`
 		Contract        struct {
 			RPC        string `long:"rpc" description:"Path or URL of an Ethereum RPC provider for payment contract operations. Must match the network of the contract."`

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -93,9 +93,13 @@ type UpdateRequest struct {
 
 // UpdateResponse is the response type for Update RPC calls.
 type UpdateResponse struct {
-	Balance      *store.Balance `json:"balance,omitempty"`
-	InvalidPeers []string       `json:"invalid_peers"`
-	// TODO: Add PoolPeers []string // PoolPeers is the set of peers that are members of the pool.
+	// Balance is the balance of the node with the pool.
+	Balance *store.Balance `json:"balance,omitempty"`
+	// InvalidPeers are peers who should be disconnected from, such as when a peer
+	// stops reporting connectivity from their side.
+	InvalidPeers []string `json:"invalid_peers"`
+	// ActivePeers are peers that the pool knows about and is tracking usage for.
+	ActivePeers []string `json:"active_peers"`
 }
 
 // PeerRequest is the request type for Peer RPC calls.

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -100,6 +100,8 @@ type UpdateResponse struct {
 	InvalidPeers []string `json:"invalid_peers"`
 	// ActivePeers are peers that the pool knows about and is tracking usage for.
 	ActivePeers []string `json:"active_peers"`
+	// LatestBlockNumber is the highest block number that the pool knows about.
+	LatestBlockNumber uint64 `json:"latest_block_number"`
 }
 
 // PeerRequest is the request type for Peer RPC calls.

--- a/pool/service.go
+++ b/pool/service.go
@@ -195,11 +195,12 @@ func (p *VipnodePool) Update(ctx context.Context, sig string, nodeID string, non
 	}
 	resp.Balance = &nodeBalance
 
+	nodeKind := node.Kind + "-light"
 	if node.IsHost {
-		logger.Printf("Host update %q: %d peers, %d active, %d invalid. %s", pretty.Abbrev(nodeID), peerTypes.Count, len(active), len(inactive), nodeBalance.String())
-	} else {
-		logger.Printf("Client update %q: %d peers, %d active, %d invalid. %s", pretty.Abbrev(nodeID), peerTypes.Count, len(active), len(inactive), nodeBalance.String())
+		nodeKind = node.Kind + "-full"
 	}
+
+	logger.Printf("Updated %s: peers=%d active=%d invalid=%d block=%d node=%s balance=%s", pretty.Abbrev(nodeID), peerTypes.Count, len(active), len(inactive), req.BlockNumber, nodeKind, nodeBalance.String())
 
 	return &resp, nil
 }

--- a/pool/service.go
+++ b/pool/service.go
@@ -341,7 +341,7 @@ func (p *VipnodePool) connect(ctx context.Context, nodeID string, req ConnectReq
 	if err := p.BalanceManager.OnClient(node); err != nil {
 		return nil, err
 	}
-	logger.Printf("New %q peer: %q", kind, pretty.Abbrev(nodeID))
+	logger.Printf("Connected %s peer: %q", req.NodeInfo.KindType(), pretty.Abbrev(nodeID))
 
 	return response, nil
 }

--- a/pool/staticpool.go
+++ b/pool/staticpool.go
@@ -13,7 +13,8 @@ var _ Pool = &StaticPool{}
 // StaticPool is a dummy implementation of a pool service that always returns
 // from the same set of host nodes. It does not do any signature checking.
 type StaticPool struct {
-	Nodes []store.Node
+	Nodes             []store.Node
+	LatestBlockNumber uint64
 }
 
 func (s *StaticPool) AddNode(nodeURI string) error {
@@ -48,6 +49,7 @@ func (s *StaticPool) Disconnect(ctx context.Context) error {
 }
 
 func (s *StaticPool) Update(ctx context.Context, req UpdateRequest) (*UpdateResponse, error) {
+	s.LatestBlockNumber = req.BlockNumber
 	return &UpdateResponse{}, nil
 }
 


### PR DESCRIPTION
- [x] Add `agent` subcommand
- [x] Deprecate `host` and `client` subcommands (with warnings)
- [x] Add set of pool-managed peers to UpdateResponse (so we can differentiate between pool-peers and random-peers at the agent level)
- [x] Add latest block number to UpdateResponse that the pool knows about. (Also adds a BlockNumberProvider interface so we can add external providers later.)
- [x] Add agent warning when the local block number is drifting too far from the pool.
- [x] Refactor main runner code into a stateful helper that can be tested better (for integration tests).
- [x] Add a basic agent integration test
- [x] Document new commands (README, etc) 
- [ ] Make sure the new `vipnode agent` is backwards compatible with the old pool.

## Stretch goals
Maybe move these into a separate PR if they don't fit
- `agent` command to run when the node is drifting? (Could be used for email notifications, or restarting, etc?)
- Support for external block number provider?
- Pool integration test? (Might need to refactor to a poolRunner)
- Staging deployment?