### PR TITLE
Fix pool metadata bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ RUN = ./$(BINARY)
 
 # Configs
 FAKEBIND = 127.0.0.1:8080
-FAKEPEERS = 0
+FAKEPEERS = 5
+FAKEBLOCK = 42
 
 all: $(BINARY)
 
@@ -43,7 +44,7 @@ fakepool: $(BINARY)
 	$(RUN) -vv pool --bind "$(FAKEBIND)" --store="memory" --allow-origin "http://localhost:3000" --contract.welcome="Welcome to the Fakepool"
 
 fakehost: $(BINARY)
-	$(RUN) -vv agent "ws://$(FAKEBIND)" --update-interval=10s --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)&fullnode=1"
+	$(RUN) -vv agent "ws://$(FAKEBIND)" --update-interval=10s --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)&fullnode=1&fakeblock=$(FAKEBLOCK)"
 
 fakehostpool: $(BINARY)
 	$(RUN) -vv agent ":memory:" --update-interval=10s --enode="enode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1@127.0.0.1:30303?discport=0" --rpc "fakenode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1?fakepeers=$(FAKEPEERS)&fullnode=1"

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -123,7 +123,7 @@ func (a *Agent) Start(p pool.Pool) error {
 		a.PoolMessageCallback(resp.Message)
 	}
 
-	if err := a.updatePeers(startCtx, p); err != nil {
+	if err := a.UpdatePeers(startCtx, p); err != nil {
 		return err
 	}
 
@@ -162,7 +162,7 @@ func (a *Agent) serveUpdates(p pool.Pool) error {
 	for {
 		select {
 		case <-ticker:
-			if err := a.updatePeers(context.Background(), p); err != nil {
+			if err := a.UpdatePeers(context.Background(), p); err != nil {
 				return err
 			}
 		case <-a.stopCh:
@@ -193,7 +193,10 @@ func (a *Agent) disconnectPeers(ctx context.Context) error {
 	return nil
 }
 
-func (a *Agent) updatePeers(ctx context.Context, p pool.Pool) error {
+// UpdatePeers sends a vipnode_update to the given pool. It will request more
+// peers if necessary. Normally this is done automatically via Agent.Start()
+// every configured interval.
+func (a *Agent) UpdatePeers(ctx context.Context, p pool.Pool) error {
 	peers, err := a.EthNode.Peers(ctx)
 	if err != nil {
 		return err

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -36,7 +36,7 @@ func TestAgent(t *testing.T) {
 	})
 
 	// Force update
-	if err := agent.updatePeers(context.Background(), p); err != nil {
+	if err := agent.UpdatePeers(context.Background(), p); err != nil {
 		t.Fatal(err)
 	}
 

--- a/ethnode/rpc.go
+++ b/ethnode/rpc.go
@@ -203,6 +203,26 @@ type PeerInfo struct {
 	} `json:"network"`
 }
 
+func (p *PeerInfo) IsFullNode() bool {
+	if p.Protocols == nil {
+		return false
+	}
+	_, ok := p.Protocols["eth"]
+	return ok
+}
+
+// Peers is a list of PeerInfo
+type Peers []PeerInfo
+
+// IDs returns a list of string IDs of the peers.
+func (peers Peers) IDs() []string {
+	r := make([]string, 0, len(peers))
+	for _, peer := range peers {
+		r = append(r, peer.ID)
+	}
+	return r
+}
+
 // EthNode is the normalized interface between different kinds of nodes.
 type EthNode interface {
 	NodeRPC() *rpc.Client

--- a/internal/fakecluster/fakecluster.go
+++ b/internal/fakecluster/fakecluster.go
@@ -1,6 +1,7 @@
 package fakecluster
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"io"
@@ -98,6 +99,21 @@ func New(hostKeys []*ecdsa.PrivateKey, clientKeys []*ecdsa.PrivateKey) (*Cluster
 		})
 	}
 	return cluster, nil
+}
+
+// Update forces an update call to the pool from all the agents
+func (c *Cluster) Update() error {
+	agents := []clusterAgent{}
+	agents = append(agents, c.Hosts...)
+	agents = append(agents, c.Clients...)
+
+	for _, a := range agents {
+		if err := a.UpdatePeers(context.Background(), a.RemotePool); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Close shuts down all the open pipes.

--- a/internal/fakecluster/fakecluster.go
+++ b/internal/fakecluster/fakecluster.go
@@ -12,7 +12,6 @@ import (
 	"github.com/vipnode/vipnode/internal/fakenode"
 	"github.com/vipnode/vipnode/jsonrpc2"
 	"github.com/vipnode/vipnode/pool"
-	"github.com/vipnode/vipnode/pool/store/memory"
 )
 
 type clusterAgent struct {
@@ -34,14 +33,14 @@ type Cluster struct {
 }
 
 // New returns a pre-connected pool of hosts and clients.
-func New(hostKeys []*ecdsa.PrivateKey, clientKeys []*ecdsa.PrivateKey) (*Cluster, error) {
+func New(p *pool.VipnodePool, hostKeys []*ecdsa.PrivateKey, clientKeys []*ecdsa.PrivateKey) (*Cluster, error) {
 	cluster := &Cluster{
+		Pool:    p,
 		Hosts:   []clusterAgent{},
 		Clients: []clusterAgent{},
 		pipes:   []io.Closer{},
 	}
 
-	cluster.Pool = pool.New(memory.New(), nil)
 	payout := ""
 	for _, hostKey := range hostKeys {
 		rpcPool2Host, rpcHost2Pool := jsonrpc2.ServePipe()
@@ -52,12 +51,14 @@ func New(hostKeys []*ecdsa.PrivateKey, clientKeys []*ecdsa.PrivateKey) (*Cluster
 
 		hostNodeID := discv5.PubkeyID(&hostKey.PublicKey).String()
 		hostNode := fakenode.Node(hostNodeID)
-		hostNodeURI := fmt.Sprintf("enode://%s@127.0.0.1:30303", hostNodeID)
-		h := &agent.Agent{EthNode: hostNode, Payout: payout}
+		h := &agent.Agent{
+			EthNode: hostNode,
+			NodeURI: fmt.Sprintf("enode://%s@127.0.0.1:30303", hostNodeID),
+			Payout:  payout,
+		}
 		if err := rpcHost2Pool.Server.RegisterMethod("vipnode_whitelist", h, "Whitelist"); err != nil {
 			return nil, err
 		}
-		h.NodeURI = hostNodeURI
 		hostPool := pool.Remote(rpcHost2Pool, hostKey)
 
 		if err := h.Start(hostPool); err != nil {
@@ -81,6 +82,7 @@ func New(hostKeys []*ecdsa.PrivateKey, clientKeys []*ecdsa.PrivateKey) (*Cluster
 
 		clientNodeID := discv5.PubkeyID(&clientKey.PublicKey).String()
 		clientNode := fakenode.Node(clientNodeID)
+		clientNode.IsFullNode = false
 		c := &agent.Agent{
 			EthNode:  clientNode,
 			NumHosts: 3,

--- a/internal/fakenode/fakenode.go
+++ b/internal/fakenode/fakenode.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"reflect"
 
 	"github.com/ethereum/go-ethereum/rpc"
 
@@ -22,6 +23,17 @@ type Calls []call
 
 func Call(method string, args ...interface{}) call {
 	return call{method, args}
+}
+
+// Has checks if the call list has this call
+func (calls Calls) Has(method string, args ...interface{}) bool {
+	want := call{method, args}
+	for _, have := range calls {
+		if reflect.DeepEqual(want, have) {
+			return true
+		}
+	}
+	return false
 }
 
 func Node(nodeID string) *FakeNode {

--- a/main.go
+++ b/main.go
@@ -157,8 +157,11 @@ func findRPC(rpcPath string) (ethnode.EthNode, error) {
 			nodeID = u.Hostname()
 		}
 		node := fakenode.Node(nodeID)
-		if numpeers, err := strconv.Atoi(u.Query().Get("fakepeers")); err == nil {
-			node.FakePeers = fakenode.FakePeers(numpeers)
+		if numPeers, err := strconv.Atoi(u.Query().Get("fakepeers")); err == nil {
+			node.FakePeers = fakenode.FakePeers(numPeers)
+		}
+		if numBlock, err := strconv.Atoi(u.Query().Get("fakeblock")); err == nil {
+			node.FakeBlockNumber = uint64(numBlock)
 		}
 		node.IsFullNode = u.Query().Get("fullnode") != ""
 

--- a/pool/status/status.go
+++ b/pool/status/status.go
@@ -136,6 +136,7 @@ func (s *PoolStatus) getStatus() (*StatusResponse, error) {
 
 // Status returns the status of the pool.
 func (s *PoolStatus) Status(ctx context.Context) (*StatusResponse, error) {
+	// Read lock to check the cache
 	s.mu.RLock()
 	cachedResp := s.cachedResp
 	s.mu.RUnlock()
@@ -145,6 +146,7 @@ func (s *PoolStatus) Status(ctx context.Context) (*StatusResponse, error) {
 		return cachedResp, nil
 	}
 
+	// Write lock to refresh the cache
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/pool/store/memory/memory.go
+++ b/pool/store/memory/memory.go
@@ -273,6 +273,7 @@ func (s *memoryStore) UpdateNodePeers(nodeID store.NodeID, peers []string, block
 	}
 	now := time.Now()
 	node.LastSeen = now
+	node.BlockNumber = blockNumber
 	numUpdated := 0
 	for _, peer := range peers {
 		// Only update peers we already know about

--- a/poolhostclient_test.go
+++ b/poolhostclient_test.go
@@ -5,19 +5,24 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/vipnode/vipnode/agent"
 	"github.com/vipnode/vipnode/internal/fakecluster"
 	"github.com/vipnode/vipnode/internal/fakenode"
 	"github.com/vipnode/vipnode/internal/keygen"
+	"github.com/vipnode/vipnode/internal/pretty"
 	"github.com/vipnode/vipnode/jsonrpc2"
 	"github.com/vipnode/vipnode/pool"
+	"github.com/vipnode/vipnode/pool/balance"
 	"github.com/vipnode/vipnode/pool/status"
+	"github.com/vipnode/vipnode/pool/store"
 	"github.com/vipnode/vipnode/pool/store/memory"
 )
 
@@ -171,20 +176,32 @@ func TestPoolHostConnectPeers(t *testing.T) {
 	hostKeys := []*ecdsa.PrivateKey{}
 	clientKeys := []*ecdsa.PrivateKey{}
 
-	for i := 0; i < 4; i++ {
+	// We limit to 3 hosts for now, because clients autoconnect to 3 hosts and
+	// it's easier to check 100% connectivity deterministically (otherwise
+	// hosts are chosen randomly)
+	i := 0
+	for ; i < 3; i++ {
 		hostKeys = append(hostKeys, keygen.HardcodedKeyIdx(t, i))
 	}
 
-	cluster, err := fakecluster.New(hostKeys, clientKeys)
+	for ; i < 5; i++ {
+		clientKeys = append(clientKeys, keygen.HardcodedKeyIdx(t, i))
+	}
+
+	poolStore := memory.New()
+	balanceManager := balance.PayPerInterval(poolStore, time.Nanosecond*1, big.NewInt(10))
+	p := pool.New(poolStore, balanceManager)
+
+	cluster, err := fakecluster.New(p, hostKeys, clientKeys)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if got, want := len(cluster.Hosts), 4; got != want {
+	if got, want := len(cluster.Hosts), len(hostKeys); got != want {
 		t.Errorf("wrong number of hosts: got %d; want %d", got, want)
 	}
 
-	if got, want := cluster.Pool.NumRemotes(), 4; got != want {
+	if got, want := cluster.Pool.NumRemotes(), len(hostKeys); got != want {
 		t.Errorf("wrong number of remotes: got %d; want %d", got, want)
 	}
 
@@ -193,7 +210,7 @@ func TestPoolHostConnectPeers(t *testing.T) {
 		t.Error(err)
 	}
 
-	if stats.NumActiveHosts != 4 {
+	if stats.NumActiveHosts != len(hostKeys) {
 		t.Errorf("wrong stats: %+v", stats)
 	}
 
@@ -222,7 +239,6 @@ func TestPoolHostConnectPeers(t *testing.T) {
 		numCalls := 0
 		for _, call := range host.Node.Calls {
 			if call.Method != "ConnectPeer" {
-				t.Errorf("unexpected call to host: %s", call)
 				continue
 			}
 			numCalls++
@@ -240,14 +256,18 @@ func TestPoolHostConnectPeers(t *testing.T) {
 		// Check a peer
 		host := cluster.Hosts[1]
 		peer := cluster.Hosts[0]
-		want := fakenode.Calls{fakenode.Call("AddTrustedPeer", peer.Node.NodeID)}
-		if got := host.Node.Calls; !reflect.DeepEqual(got, want) {
-			t.Errorf("peer host calls do not match:\n  got: %s;\n want: %s", got, want)
+		if !host.Node.Calls.Has("AddTrustedPeer", peer.Node.NodeID) {
+			t.Errorf("peer host calls missing AddTrustedPeer for %s, got:\n%s", peer.Node.NodeID, host.Node.Calls)
 		}
 		// We can't check the Peers of the host here because it's a FakeNode so
 		// it does not actually initiate a connection on Connect.
 	}
 
+	// Run a couple of updates to make sure everyone who wants to connect has
+	// connected.
+	if err := cluster.Update(); err != nil {
+		t.Fatal(err)
+	}
 	if err := cluster.Update(); err != nil {
 		t.Fatal(err)
 	}
@@ -274,6 +294,44 @@ func TestPoolHostConnectPeers(t *testing.T) {
 		t.Errorf("PoolStatus: wrong block number for first host: got %d; want %d", got, want)
 	} else if got, want := firstHost.NumPeers, len(cluster.Hosts)-1; got != want {
 		t.Errorf("PoolStatus: wrong number of peers for first host: got %d; want %d", got, want)
+	}
+
+	{
+		// Check balances
+		total := new(big.Int)
+		for _, a := range cluster.Hosts {
+			nodeID := a.Node.NodeID
+			b, err := poolStore.GetNodeBalance(store.NodeID(nodeID))
+			if err != nil {
+				t.Fatal(err)
+			} else if b.Credit.Cmp(new(big.Int)) <= 0 {
+				// Hosts should have a positive balance
+				t.Errorf("wrong balance for host %s: %d", pretty.Abbrev(nodeID), &b.Credit)
+			}
+			t.Logf("balance for host %s: %d", pretty.Abbrev(nodeID), &b.Credit)
+			total = total.Add(total, &b.Credit)
+		}
+
+		if total.Cmp(new(big.Int)) <= 0 {
+			t.Errorf("Balance check: Total hosts balance should be positive: %d", total)
+		}
+
+		for _, a := range cluster.Clients {
+			nodeID := a.Node.NodeID
+			b, err := poolStore.GetNodeBalance(store.NodeID(nodeID))
+			if err != nil {
+				t.Fatal(err)
+			} else if b.Credit.Cmp(new(big.Int)) >= 0 {
+				// Clients should have a negative balance
+				t.Errorf("wrong balance for client %s: %d", pretty.Abbrev(nodeID), &b.Credit)
+			}
+			t.Logf("balance for client %s: %d", pretty.Abbrev(nodeID), &b.Credit)
+			total = total.Add(total, &b.Credit)
+		}
+
+		if total.Cmp(new(big.Int)) != 0 {
+			t.Errorf("Balance check: Total balance should be zero: %d", total)
+		}
 	}
 
 	err = cluster.Close()


### PR DESCRIPTION
- We weren't counting full nodes in the node set (because vipnode was originally designed to only track host->client relationships, not host-to-host). This changes to track all peers, regardless whether they're light clients or full nodes. In theory, the money bits should keep working because host-to-host debits will cancel out. There is some testing for this.
- The store implementations weren't saving some metadata (block number), this adds a fix and some more scenarios to the store testsuite to cover it.
- Adds integration test for more pool status metrics (block number, peers, balances)