### PR TITLE
pool: Log full enode string on connected peer

### DIFF
--- a/pool/remote.go
+++ b/pool/remote.go
@@ -34,6 +34,7 @@ func (p *RemotePool) getNonce() int64 {
 	return time.Now().UnixNano()
 }
 
+// DEPRECATED
 func (p *RemotePool) Host(ctx context.Context, req HostRequest) (*HostResponse, error) {
 	signedReq := request.NodeRequest{
 		Method:    "vipnode_host",
@@ -53,6 +54,7 @@ func (p *RemotePool) Host(ctx context.Context, req HostRequest) (*HostResponse, 
 	return &resp, nil
 }
 
+// DEPRECATED
 func (p *RemotePool) Client(ctx context.Context, req ClientRequest) (*ClientResponse, error) {
 	signedReq := request.NodeRequest{
 		Method:    "vipnode_client",

--- a/pool/service.go
+++ b/pool/service.go
@@ -339,7 +339,12 @@ func (p *VipnodePool) connect(ctx context.Context, nodeID string, req ConnectReq
 	if err := p.BalanceManager.OnClient(node); err != nil {
 		return nil, err
 	}
-	logger.Printf("Connected %s peer: %q", req.NodeInfo.KindType(), pretty.Abbrev(nodeID))
+
+	enode := node.URI
+	if enode == "" {
+		enode = "enode://" + nodeID + "@"
+	}
+	logger.Printf("Connected %s peer: %q", req.NodeInfo.KindType(), enode)
 
 	return response, nil
 }


### PR DESCRIPTION
This will correspond to the effective peer connect instruction when
peers are shared. Light clients don't have a host/port.

New logs look like this:

> [pool] 2019/07/10 13:29:34 Connected geth-light peer: "enode://85fbed4332ed4329ca2283f26606618815ae83a870c523bb99b0b2e9dfe5af3b4699c2830ecdeb67519d62362db44aa5a8cafee523e3ab8c76aeef1016f424a4@"
> [pool] 2019/07/10 13:29:34 Updated 85fbed4332ed…: peers=5 active=0 invalid=0 block=0 node=geth-light balance=Balance(<null account>, 0 wei)
> [pool] 2019/07/10 13:29:41 Connected geth-full peer: "enode://f21f0692b06019ae3f40d78d8b309487fc75f75b76df71d76196c3514272adf30aca4b2451181eb22208757cd4363923e17723d2f2ddf7b0175ecb87dada7ca1@127.0.0.1:30303"
> [pool] 2019/07/10 13:29:41 Updated f21f0692b060…: peers=5 active=0 invalid=0 block=42 node=geth-full balance=Balance(<null account>, 0 wei)