### PR TITLE
pool: requestHosts skip already-active peers and disconnected hosts

### DIFF
--- a/poolhostclient_test.go
+++ b/poolhostclient_test.go
@@ -106,14 +106,12 @@ func TestPoolHostClient(t *testing.T) {
 	}
 	want = fakenode.Calls{
 		fakenode.Call("ConnectPeer", hostNodeURI),
-		fakenode.Call("ConnectPeer", hostNodeURI),
 	}
 	if got := clientNode.Calls; !reflect.DeepEqual(got, want) {
 		t.Errorf("clientNode.Calls:\n  got %q;\n want %q", got, want)
 	}
 
 	want = fakenode.Calls{
-		fakenode.Call("AddTrustedPeer", clientNodeID),
 		fakenode.Call("AddTrustedPeer", clientNodeID),
 	}
 	if got := hostNode.Calls; !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
- requestHost no longer returns peers that are already known peers to the requesting nodeID
- requestHost no longer bails with an error if an active host candidate is disconnected from the pool (will now just log and skips)

Fixes #56, turns out it wasn't a leak but just bailing unnecessarily.