### PR TITLE
main: Add agent --enode.host override

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -121,6 +121,14 @@ func (runner *agentRunner) LoadAgent(options Options) error {
 		// because the pool will use the connection's ip as the host.
 		a.NodeURI = remoteEnode
 	}
+	if options.Agent.NodeHost != "" {
+		nodeURI, err := url.Parse(a.NodeURI)
+		if err != nil {
+			return fmt.Errorf("failed to parse NodeURI during NodeHost override: %s", err)
+		}
+		nodeURI.Host = options.Agent.NodeHost
+		a.NodeURI = nodeURI.String()
+	}
 	a.PoolMessageCallback = func(msg string) {
 		logger.Alertf("Message from pool: %s", msg)
 	}

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ type Options struct {
 		RPC            string `long:"rpc" description:"RPC path or URL of the host node."`
 		NodeKey        string `long:"nodekey" description:"Path to the host node's private key."`
 		NodeURI        string `long:"enode" description:"Public enode://... URI for clients to connect to. (If node is on a different IP from the vipnode agent)"`
+		NodeHost       string `long:"enode.host" description:"Override just the host component of reported enode:// URI. Useful for overriding network routing."`
 		Payout         string `long:"payout" description:"Ethereum wallet address to associate pool credits."`
 		MinPeers       int    `long:"min-peers" description:"Minimum number of peers to maintain." default:"3"`
 		UpdateInterval string `long:"update-interval" description:"Time between updates sent to pool, should be under 120s." default:"60s"`


### PR DESCRIPTION
Decided to leave the `--enode.host` flag not-hidden, hope I don't regret it. :P

```
[agent command options]
          --rpc=             RPC path or URL of the host node.
          --nodekey=         Path to the host node's private key.
          --enode=           Public enode://... URI for clients to connect to. (If node is on a different IP from the vipnode agent)
          --enode.host=      Override just the host component of reported enode:// URI. Useful for overriding network routing.
          --payout=          Ethereum wallet address to associate pool credits.
          --min-peers=       Minimum number of peers to maintain. (default: 3)
          --update-interval= Time between updates sent to pool, should be under 120s. (default: 60s)
```