### PR TITLE
ethnode: Fix new geth nodeID format check

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -271,8 +271,17 @@ func (a *Agent) AddPeers(ctx context.Context, p pool.Pool, num int) error {
 		Num:  num,
 		Kind: kind,
 	})
-	if err != nil && jsonrpc2.IsErrorCode(err, jsonrpc2.ErrCodeInternal) && strings.HasPrefix(err.Error(), "no available") {
-		return ErrNoPeers
+	if err != nil && jsonrpc2.IsErrorCode(err, jsonrpc2.ErrCodeInternal) {
+		if strings.HasPrefix(err.Error(), "no available") {
+			return ErrNoPeers
+		} else {
+			// This can happen if there are some incompatible agents on the
+			// pool (e.g. outdated broken vipnode version)
+			logger.Printf("AddPeers RPC failed: %s", err)
+			// We can't recover on this end. This should also yield errors on
+			// the broken agents' side so hopefully they'll update soon.
+			return ErrNoPeers
+		}
 	} else if err != nil {
 		return AgentPoolError{err, "Failed during pool peer request"}
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -277,7 +277,7 @@ func (a *Agent) AddPeers(ctx context.Context, p pool.Pool, num int) error {
 		} else {
 			// This can happen if there are some incompatible agents on the
 			// pool (e.g. outdated broken vipnode version)
-			logger.Printf("AddPeers RPC failed: %s", err)
+			logger.Printf("AddPeers RPC failed (possibly due to outdated agents on the pool): %s", err)
 			// We can't recover on this end. This should also yield errors on
 			// the broken agents' side so hopefully they'll update soon.
 			return ErrNoPeers

--- a/ethnode/geth.go
+++ b/ethnode/geth.go
@@ -2,7 +2,6 @@ package ethnode
 
 import (
 	"context"
-	"errors"
 	"strings"
 )
 
@@ -32,19 +31,6 @@ type gethNode struct {
 
 func (n *gethNode) Kind() NodeKind {
 	return Geth
-}
-
-func (n *gethNode) CheckCompatible(ctx context.Context) error {
-	// TODO: Make sure we have the necessary APIs available, maybe version check?
-	var result interface{}
-	err := n.client.CallContext(ctx, &result, "admin_addTrustedPeer", "")
-	if err == nil {
-		return errors.New("failed to detect compatibility")
-	}
-	if err, ok := err.(codedError); ok && err.ErrorCode() == errCodeMethodNotFound {
-		return err
-	}
-	return nil
 }
 
 func (n *gethNode) ConnectPeer(ctx context.Context, nodeURI string) error {


### PR DESCRIPTION
- ethnode: Make sure nodeIDs start with `enode://`, fixes #65
- agent: Don't error fatally on AddPeer failures. Broken versions of vipnode agents will fail to whitelist, for example, but this should not break good agents. Opened #66 to improve this on the pool side.