### PR TITLE
agent: Add StrictPeers mode

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -109,6 +109,7 @@ func (runner *agentRunner) LoadAgent(options Options) error {
 		Version:        fmt.Sprintf("vipnode/agent/%s", Version),
 		UpdateInterval: updateInterval,
 		NumHosts:       options.Agent.MinPeers,
+		StrictPeers:    options.Agent.StrictPeers,
 	}
 	runner.Agent = a
 	if options.Agent.NodeURI != "" {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3,8 +3,10 @@ package agent
 import (
 	"context"
 	"os"
+	"reflect"
 	"testing"
 
+	"github.com/vipnode/vipnode/ethnode"
 	"github.com/vipnode/vipnode/internal/fakenode"
 	"github.com/vipnode/vipnode/pool"
 	"github.com/vipnode/vipnode/pool/store"
@@ -24,6 +26,7 @@ func TestAgent(t *testing.T) {
 	if err := agent.Start(p); err != nil {
 		t.Fatal(err)
 	}
+	defer agent.Stop()
 
 	if peers, err := agent.EthNode.Peers(context.Background()); err != nil {
 		t.Fatal(err)
@@ -32,7 +35,7 @@ func TestAgent(t *testing.T) {
 	}
 
 	p.Nodes = append(p.Nodes, store.Node{
-		URI: "foo",
+		URI: "enode://bar@127.0.0.1:30303",
 	})
 
 	// Force update
@@ -44,5 +47,91 @@ func TestAgent(t *testing.T) {
 		t.Fatal(err)
 	} else if got, want := len(peers), 1; got != want {
 		t.Errorf("wrong number of peers: got %d; want %d", got, want)
+	}
+}
+
+func TestAgentStrictPeers(t *testing.T) {
+	SetLogger(os.Stderr)
+
+	node := fakenode.Node("foo")
+	agent := Agent{
+		EthNode:     node,
+		NumHosts:    5,
+		StrictPeers: true,
+	}
+
+	fakepeers := fakenode.FakePeers(15)
+
+	// Prefill peers
+	node.FakePeers = fakepeers[:10]
+
+	// Confirm peers
+	if peers, err := agent.EthNode.Peers(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if got, want := len(peers), 10; got != want {
+		t.Errorf("wrong number of peers: got %d; want %d", got, want)
+	}
+
+	p := &pool.StaticPool{}
+	p.Nodes = append(
+		p.Nodes,
+		// New node
+		store.Node{URI: "enode://bar@127.0.0.1:30303"},
+		// Include a subset of the original
+		store.Node{URI: fakepeers[4].EnodeURI()},
+		store.Node{URI: fakepeers[5].EnodeURI()},
+		// Mismatch host
+		store.Node{URI: "enode://" + fakepeers[6].EnodeID() + "@42.42.42.42:30303"},
+	)
+
+	expectURIs := make([]string, 0, len(p.Nodes))
+	for _, n := range p.Nodes {
+		expectURIs = append(expectURIs, n.URI)
+	}
+
+	if err := agent.Start(p); err != nil {
+		t.Fatal(err)
+	}
+	defer agent.Stop()
+
+	// Force update
+	if err := agent.UpdatePeers(context.Background(), p); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set should match the pool set
+	if peers, err := agent.EthNode.Peers(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if got, want := len(peers), len(expectURIs); got != want {
+		t.Errorf("wrong number of peers: got %d; want %d", got, want)
+	} else if got, want := ethnode.Peers(peers).URIs(), expectURIs; !reflect.DeepEqual(got, want) {
+		t.Errorf("mismatched enode URIs:\n got: %s\nwant: %s", got, want)
+	}
+
+	// One more time, add more peers
+	if err := node.ConnectPeer(context.Background(), fakepeers[11].EnodeURI()); err != nil {
+		t.Fatal(err)
+	}
+	if err := node.ConnectPeer(context.Background(), fakepeers[12].EnodeURI()); err != nil {
+		t.Fatal(err)
+	}
+	if peers, err := agent.EthNode.Peers(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if got, want := len(peers), len(expectURIs)+2; got != want {
+		t.Errorf("wrong number of peers: got %d; want %d", got, want)
+	}
+
+	// Force update
+	if err := agent.UpdatePeers(context.Background(), p); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set should match the pool set
+	if peers, err := agent.EthNode.Peers(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if got, want := len(peers), len(expectURIs); got != want {
+		t.Errorf("wrong number of peers: got %d; want %d", got, want)
+	} else if got, want := ethnode.Peers(peers).URIs(), expectURIs; !reflect.DeepEqual(got, want) {
+		t.Errorf("mismatched enode URIs:\n got: %s\nwant: %s", got, want)
 	}
 }

--- a/ethnode/rpc.go
+++ b/ethnode/rpc.go
@@ -238,6 +238,15 @@ func (peers Peers) IDs() []string {
 	return r
 }
 
+// URIs returns a list of connection EnodeURIs for the peers.
+func (peers Peers) URIs() []string {
+	r := make([]string, 0, len(peers))
+	for _, peer := range peers {
+		r = append(r, peer.EnodeURI())
+	}
+	return r
+}
+
 // EthNode is the normalized interface between different kinds of nodes.
 type EthNode interface {
 	NodeRPC() *rpc.Client

--- a/ethnode/rpc.go
+++ b/ethnode/rpc.go
@@ -3,7 +3,6 @@ package ethnode
 import (
 	"context"
 	"encoding/json"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -311,29 +310,4 @@ func RemoteNode(client *rpc.Client) (EthNode, error) {
 	}
 
 	return node, nil
-}
-
-// EnodeEqual returns whether two enode:// strings are equivalent after
-// normalization, comparing only the enodeID and remote address.
-// Failure to parse returns false. Remote address "[::]" acts as a wildcard.
-func EnodeEqual(a, b string) bool {
-	uriA, err := url.Parse(a)
-	if err != nil || uriA.User == nil {
-		return false
-	}
-	uriB, err := url.Parse(b)
-	if err != nil || uriB.User == nil {
-		return false
-	}
-
-	if uriA.User.Username() != uriB.User.Username() {
-		return false
-	}
-	if uriA.Hostname() == "::" || uriB.Hostname() == "::" {
-		if uriA.Port() != uriB.Port() {
-			return false
-		}
-		return true
-	}
-	return uriA.Host == uriB.Host
 }

--- a/ethnode/rpc_test.go
+++ b/ethnode/rpc_test.go
@@ -29,3 +29,28 @@ func TestParseUserAgent(t *testing.T) {
 		}
 	}
 }
+
+func TestEnodeEqual(t *testing.T) {
+	testcases := []struct {
+		A, B string
+		Want bool
+	}{
+		{"enode://foo@bar", "enode://foo@bar", true},
+		{"enode://foo@bar", "enode://foo@bar", true},
+		{"enode://foo@bar:30303", "enode://foo@[::]:30303", true},
+		{"enode://foo@[::]:30303", "enode://foo@[::]:30303", true},
+		{"enode://foo@[::]:30303", "enode://foo@1.1.1.1:30303", true},
+		{"enode://foo@[::]:30303", "enode://foo@1.1.1.1:40404", false},
+		{"enode://foo@[::]:30303", "enode://foo@", false},
+		{"enode://foo@1.1.1.1:30303", "enode://foo@", false},
+		{"enode://foo@1.1.1.1:30303", "enode://foo@2.2.2.2:30303", false},
+		{"enode://foo@1.1.1.1:30303", "enode://foo@1.1.1.1:40404", false},
+	}
+
+	for i, tc := range testcases {
+		got, want := EnodeEqual(tc.A, tc.B), tc.Want
+		if got != want {
+			t.Errorf("[case %d] %q ?= %q is %t", i, tc.A, tc.B, got)
+		}
+	}
+}

--- a/ethnode/rpc_test.go
+++ b/ethnode/rpc_test.go
@@ -29,28 +29,3 @@ func TestParseUserAgent(t *testing.T) {
 		}
 	}
 }
-
-func TestEnodeEqual(t *testing.T) {
-	testcases := []struct {
-		A, B string
-		Want bool
-	}{
-		{"enode://foo@bar", "enode://foo@bar", true},
-		{"enode://foo@bar", "enode://foo@bar", true},
-		{"enode://foo@bar:30303", "enode://foo@[::]:30303", true},
-		{"enode://foo@[::]:30303", "enode://foo@[::]:30303", true},
-		{"enode://foo@[::]:30303", "enode://foo@1.1.1.1:30303", true},
-		{"enode://foo@[::]:30303", "enode://foo@1.1.1.1:40404", false},
-		{"enode://foo@[::]:30303", "enode://foo@", false},
-		{"enode://foo@1.1.1.1:30303", "enode://foo@", false},
-		{"enode://foo@1.1.1.1:30303", "enode://foo@2.2.2.2:30303", false},
-		{"enode://foo@1.1.1.1:30303", "enode://foo@1.1.1.1:40404", false},
-	}
-
-	for i, tc := range testcases {
-		got, want := EnodeEqual(tc.A, tc.B), tc.Want
-		if got != want {
-			t.Errorf("[case %d] %q ?= %q is %t", i, tc.A, tc.B, got)
-		}
-	}
-}

--- a/internal/fakenode/fakenode_test.go
+++ b/internal/fakenode/fakenode_test.go
@@ -8,16 +8,34 @@ import (
 
 func TestFakeNode(t *testing.T) {
 	n := Node("foo")
-	n.ConnectPeer(context.Background(), "abc")
+	if err := n.ConnectPeer(context.Background(), "enode://abc@127.0.0.1"); err != nil {
+		t.Fatal(err)
+	}
 
 	if len(n.Calls) != 1 {
 		t.Errorf("wrong number of calls: %d", len(n.Calls))
 	}
 
 	expected := Calls{
-		Call("ConnectPeer", "abc"),
+		Call("ConnectPeer", "enode://abc@127.0.0.1"),
 	}
 	if !reflect.DeepEqual(n.Calls, expected) {
 		t.Errorf("got: %s; want: %s", n.Calls, expected)
+	}
+
+	if peers, err := n.Peers(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if len(peers) != 1 {
+		t.Errorf("wrong number of peers: %s", peers)
+	}
+
+	if err := n.DisconnectPeer(context.Background(), "abc"); err != nil {
+		t.Fatal(err)
+	}
+
+	if peers, err := n.Peers(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if len(peers) != 0 {
+		t.Errorf("wrong number of peers: %s", peers)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ type Options struct {
 		NodeHost       string `long:"enode.host" description:"Override just the host component of reported enode:// URI. Useful for overriding network routing."`
 		Payout         string `long:"payout" description:"Ethereum wallet address to associate pool credits."`
 		MinPeers       int    `long:"min-peers" description:"Minimum number of peers to maintain." default:"3"`
+		StrictPeers    bool   `long:"strict-peers" description:"Disconnect peers that were not provided by the pool."`
 		UpdateInterval string `long:"update-interval" description:"Time between updates sent to pool, should be under 120s." default:"60s"`
 	} `command:"agent" description:"Connect as a node to a pool or another vipnode."`
 


### PR DESCRIPTION
Add `vipnode agent --strict-peers` flag which will disconnect from any peers that aren't returned from the pool updates as "active" (aka peers that are registered with the pool and have sent an update within the past 120s).

Fixes #70