### PR TITLE
pool/store: Fix inverted logic on inactive deadline checks

### DIFF
--- a/pool/store/badger/badger.go
+++ b/pool/store/badger/badger.go
@@ -422,7 +422,7 @@ func (s *badgerStore) UpdateNodePeers(nodeID store.NodeID, peers []string, block
 
 		inactiveDeadline := now.Add(-store.ExpireInterval)
 		for nodeID, timestamp := range nodePeers {
-			if timestamp.Before(inactiveDeadline) {
+			if timestamp.After(inactiveDeadline) {
 				continue
 			}
 			delete(nodePeers, nodeID)

--- a/pool/store/memory/memory.go
+++ b/pool/store/memory/memory.go
@@ -284,8 +284,8 @@ func (s *memoryStore) UpdateNodePeers(nodeID store.NodeID, peers []string, block
 			// Skip bad peers
 			continue
 		}
-		if _, ok := s.nodes[peerID]; ok {
-			node.peers[peerID] = now
+		if peer, ok := s.nodes[peerID]; ok {
+			node.peers[peerID] = peer.LastSeen
 		}
 	}
 

--- a/pool/store/testsuite.go
+++ b/pool/store/testsuite.go
@@ -192,6 +192,10 @@ func TestSuite(t *testing.T, newStore func() Store) {
 			t.Errorf("unexpected error: %s", err)
 		}
 
+		nodes[2].LastSeen = time.Now()
+		_ = s.SetNode(nodes[2])
+		nodes[3].LastSeen = time.Now()
+		_ = s.SetNode(nodes[3])
 		if inactive, err := s.UpdateNodePeers(node.ID, newPeers, blockNumber); err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else if len(inactive) != 0 {


### PR DESCRIPTION
I've tested this on our local cluster and it seems to resolve the surprise `InactivePeers`.  I think I see now what was happening:

- usually the `numUpdated == len(node.peers)` check was short-circuiting the inactive check.
- but occasionally if the number of peers changed (e.g. due to a peering disconnect because of a devp2p timeout), it would cause the short-circuit to not activate on all the nodes in the pool, leading to the cascading disconnects and the flapping between inactive and not.

I first tested this by leaving it as `.Before` but removing the short-circuit, and the peering looked as unstable immediately as it did during the peering issues we'd seen:

<img width="765" alt="image" src="https://user-images.githubusercontent.com/53520/65547675-cfa77c00-dece-11e9-8f1d-9411d000e439.png">

In the above graph the pool w/o the short-circuit was running from ~19:07 - 19:12 UTC, and the code in this PR was running on the pool server at 19:13 onwards, the peering was remaining quite stable since, but has only been running for ~1h now.

I haven't checked the unit tests yet as to why they were passing before, but my guess is they weren't fully exercising the expiration timing.