### PR TITLE
pool, agent: StrictPeers checking for remote host matching

### DIFF
--- a/ethnode/nodeuri.go
+++ b/ethnode/nodeuri.go
@@ -1,0 +1,63 @@
+package ethnode
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// ParseNodeURI takes an "enode://..." string (Ethereum Node URI) and parses it to
+// the relevant components.
+func ParseNodeURI(enode string) (*NodeURI, error) {
+	if !strings.HasPrefix(enode, "enode://") && !strings.Contains(enode, "://") {
+		enode = "enode://" + enode
+	}
+
+	u, err := url.Parse(enode)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "enode" {
+		return nil, errors.New("invalid enode scheme: " + u.Scheme)
+	}
+
+	// Future versions of Ethereum might support DNS-resolved hostnames instead
+	// of IPs, so we avoid stripping out hosts.
+	if hostname := u.Hostname(); hostname == "localhost" {
+		u.Host = ""
+	} else if ip := net.ParseIP(hostname); ip.IsUnspecified() || ip.IsLoopback() {
+		u.Host = ""
+	}
+
+	r := NodeURI(*u)
+	return &r, nil
+}
+
+// NodeURI is a representation of an Ethereum Node URI, represented as an
+// "enode://" string
+type NodeURI url.URL
+
+// ID returns the EnodeID
+func (u *NodeURI) ID() string {
+	if u.Scheme == "" {
+		// "<ID>"
+		return u.Path
+	}
+	if u.User == nil {
+		// "enode://<ID>"
+		return u.Host
+	}
+	// "enode://<ID>@<Host>"
+	return u.User.Username()
+}
+
+// HostPort returns the remote host:port component required to connect to the
+// node, if included in the enode URI. If no remote address is provided, then
+// empty string is returned.
+func (u *NodeURI) RemoteAddress() string {
+	if u.User == nil {
+		return ""
+	}
+	return u.Host
+}

--- a/ethnode/nodeuri.go
+++ b/ethnode/nodeuri.go
@@ -22,14 +22,6 @@ func ParseNodeURI(enode string) (*NodeURI, error) {
 		return nil, errors.New("invalid enode scheme: " + u.Scheme)
 	}
 
-	// Future versions of Ethereum might support DNS-resolved hostnames instead
-	// of IPs, so we avoid stripping out hosts.
-	if hostname := u.Hostname(); hostname == "localhost" {
-		u.Host = ""
-	} else if ip := net.ParseIP(hostname); ip.IsUnspecified() || ip.IsLoopback() {
-		u.Host = ""
-	}
-
 	r := NodeURI(*u)
 	return &r, nil
 }
@@ -59,5 +51,14 @@ func (u *NodeURI) RemoteAddress() string {
 	if u.User == nil {
 		return ""
 	}
+
+	// Future versions of Ethereum might support DNS-resolved hostnames instead
+	// of IPs, so we avoid stripping out hosts.
+	if hostname := (*url.URL)(u).Hostname(); hostname == "localhost" {
+		return ""
+	} else if ip := net.ParseIP(hostname); ip.IsUnspecified() || ip.IsLoopback() {
+		return ""
+	}
+
 	return u.Host
 }

--- a/ethnode/nodeuri_test.go
+++ b/ethnode/nodeuri_test.go
@@ -1,0 +1,51 @@
+package ethnode
+
+import "testing"
+
+func TestNodeURI(t *testing.T) {
+	testcases := []struct {
+		Input         string
+		IsError       bool
+		ID            string
+		RemoteAddress string
+	}{
+		{"enode://someid@1.2.3.4:30303", false, "someid", "1.2.3.4:30303"},
+		{"foo://someid@1.2.3.4:30303", true, "", ""},
+		{"someid@1.2.3.4:30303", false, "someid", "1.2.3.4:30303"},
+		{"someid@vipnode.org:30303", false, "someid", "vipnode.org:30303"},
+		{"someid@localhost:30303", false, "someid", ""},
+		{"someid@127.0.0.42:30303", false, "someid", ""},
+		{"someid@vipnode.org", false, "someid", "vipnode.org"},
+		{
+			Input:         "enode://2c23f8da76a7ecb6e8b220a9165788c0229f7c05ce63102802f72770ac4240ece94596204564702eede6c0ad902b366dcbf0209b246ec64aed3cf1300d77ecf7@18.179.8.13:41100?discport=30301",
+			IsError:       false,
+			ID:            "2c23f8da76a7ecb6e8b220a9165788c0229f7c05ce63102802f72770ac4240ece94596204564702eede6c0ad902b366dcbf0209b246ec64aed3cf1300d77ecf7",
+			RemoteAddress: "18.179.8.13:41100",
+		},
+		{
+			Input:         "enode://someid@[::]:30303?discport=0",
+			IsError:       false,
+			ID:            "someid",
+			RemoteAddress: "",
+		},
+	}
+
+	for i, tc := range testcases {
+		u, err := ParseNodeURI(tc.Input)
+		if err != nil {
+			if !tc.IsError {
+				t.Errorf("[%d] unexpected error: %q", i, err)
+			}
+			continue
+		} else if tc.IsError {
+			t.Errorf("[%d] missing expected error", i)
+			continue
+		}
+		if got, want := u.ID(), tc.ID; got != want {
+			t.Errorf("[%d] ID - got: %q; want %q", i, got, want)
+		}
+		if got, want := u.RemoteAddress(), tc.RemoteAddress; got != want {
+			t.Errorf("[%d] RemoteAddress - got: %q; want %q", i, got, want)
+		}
+	}
+}

--- a/pool/nodeuri.go
+++ b/pool/nodeuri.go
@@ -9,6 +9,7 @@ import (
 )
 
 // normalizeNodeURI takes an enode:// URI string and some defaults to replace any missing components.
+// FIXME: Replace with ethnode.ParseNodeURI
 func normalizeNodeURI(nodeURI, nodeID, defaultHost, defaultPort string) (string, error) {
 	host, port := defaultHost, defaultPort
 

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -104,8 +104,14 @@ type UpdateResponse struct {
 	Balance *store.Balance `json:"balance,omitempty"`
 	// InvalidPeers are peers who should be disconnected from, such as when a peer
 	// stops reporting connectivity from their side.
+	// FIXME: These are presently just Node IDs, but they will be changed to
+	// enode:// strings in a future version.
+	// Use ethnode.ParseNodeURI(peerID).ID() to parse defensively.
 	InvalidPeers []string `json:"invalid_peers"`
-	// ActivePeers are peers that the pool knows about and is tracking usage for.
+	// ActivePeers are peers' enode:// strings as the pool knows about and is
+	// tracking usage for. The pool might know the same node ID under a
+	// different host route than the agent node is connected. StrictPeering can
+	// be used to make sure routing is matching.
 	ActivePeers []string `json:"active_peers"`
 	// LatestBlockNumber is the highest block number that the pool knows about.
 	LatestBlockNumber uint64 `json:"latest_block_number"`

--- a/pool/service.go
+++ b/pool/service.go
@@ -170,7 +170,7 @@ func (p *VipnodePool) Update(ctx context.Context, sig string, nodeID string, non
 		resp.InvalidPeers = append(resp.InvalidPeers, string(peerID))
 	}
 	for _, peerNode := range active {
-		resp.ActivePeers = append(resp.ActivePeers, string(peerNode.ID))
+		resp.ActivePeers = append(resp.ActivePeers, peerNode.URI)
 	}
 	if p.BlockNumberProvider != nil {
 		resp.LatestBlockNumber, err = p.BlockNumberProvider(p.RestrictNetwork)


### PR DESCRIPTION
- Add `ethnode.ParseNodeURI(...)`, similar to `url.Parse(...)`. Closes #76.
- `UpdateResponse.ActivePeers` are now `enode://` strings instead of just NodeIDs. This should be safe for previous versions because they only looked at `len(ActivePeers)` rather than actual values.
- In the future, `UpdateResponse.InvalidPeers` might also be changed to `enode://` strings for consistency, though thinking about it more it might not make sense since invalid peers are "disconnected" so the pool doesn't necessarily know about their prior host/port etc. Maybe just change them to an `enode://` string with an empty host? (Updated code to parse defensively so this is a less-breaking change in the future.)
- Added hostname checking to `StrictMode` after being normalized with `ParseNodeURI`. Closes #79