### PR TITLE
agent: StrictPeers: only check host, not port

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -244,7 +244,7 @@ func (a *Agent) UpdatePeers(ctx context.Context, p pool.Pool) error {
 				logger.Printf("Failed to parse active peer enode from pool %q: %s", err, p)
 				continue
 			}
-			lookup[uri.ID()] = uri.RemoteAddress()
+			lookup[uri.ID()] = uri.RemoteHost()
 		}
 
 		// Mark any non-active peers as invalid. These should be a superset of
@@ -254,7 +254,7 @@ func (a *Agent) UpdatePeers(ctx context.Context, p pool.Pool) error {
 			uri, err := ethnode.ParseNodeURI(p.EnodeURI())
 			if err != nil {
 				logger.Printf("Failed to parse peer enode %q: %s", err, p.EnodeURI())
-			} else if remoteAddr, ok := lookup[uri.ID()]; ok && uri.RemoteAddress() == remoteAddr {
+			} else if remoteAddr, ok := lookup[uri.ID()]; ok && uri.RemoteHost() == remoteAddr {
 				continue // Local peer matching active peer on pool
 			}
 			update.InvalidPeers = append(update.InvalidPeers, p.EnodeURI())

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -133,7 +133,7 @@ func TestAgentStrictPeers(t *testing.T) {
 		fakepeers[4].EnodeURI(),
 		fakepeers[5].EnodeURI(),
 		"enode://" + fakepeers[6].EnodeID() + "@1.2.3.4:30303",
-		"enode://bar@1.1.1.1:40404",
+		"enode://bar@1.1.1.1:30303", // Port is not checked
 	}
 
 	// Set should match the pool set. This check only passes with StrictMode

--- a/ethnode/nodeuri.go
+++ b/ethnode/nodeuri.go
@@ -44,21 +44,39 @@ func (u *NodeURI) ID() string {
 	return u.User.Username()
 }
 
-// HostPort returns the remote host:port component required to connect to the
-// node, if included in the enode URI. If no remote address is provided, then
-// empty string is returned.
-func (u *NodeURI) RemoteAddress() string {
+func (u *NodeURI) hasRemote() bool {
 	if u.User == nil {
-		return ""
+		return false
 	}
 
 	// Future versions of Ethereum might support DNS-resolved hostnames instead
 	// of IPs, so we avoid stripping out hosts.
 	if hostname := (*url.URL)(u).Hostname(); hostname == "localhost" {
-		return ""
+		return false
 	} else if ip := net.ParseIP(hostname); ip.IsUnspecified() || ip.IsLoopback() {
+		return false
+	}
+
+	return true
+}
+
+// RemoteAddress returns the remote host:port component required to connect to
+// the node, if included in the enode URI. If no remote address is provided,
+// then empty string is returned.
+func (u *NodeURI) RemoteAddress() string {
+	if !u.hasRemote() {
 		return ""
 	}
 
 	return u.Host
+}
+
+// RemoteHost returns the host of the remote NodeURI, if a remote address is
+// defined.  Otherwise empty string is returned.
+func (u *NodeURI) RemoteHost() string {
+	if !u.hasRemote() {
+		return ""
+	}
+
+	return (*url.URL)(u).Hostname()
 }


### PR DESCRIPTION
We were looking at RemotePort which is often an ephemeral port established during the UDP connection. It's not predictable or useful to check, and was causing a lot of StrictPeers thrashing.