### PR TITLE
agent: Add invalid peer enodes to disconnect log message

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -261,7 +261,7 @@ func (a *Agent) UpdatePeers(ctx context.Context, p pool.Pool) error {
 		}
 
 		if len(update.InvalidPeers) > 0 {
-			logger.Printf("Disconnecting from mismatched StrictPeers: %d", len(update.InvalidPeers))
+			logger.Printf("Disconnecting from %d mismatched StrictPeers: %q", len(update.InvalidPeers), update.InvalidPeers)
 		}
 	}
 


### PR DESCRIPTION
Adding some better logging to help debug in the future.

@ryanschneider Can you think of anything else that would help in this scenario?