### PR TITLE
ethnode, main: Fix Parity 2.5 compatibility

### DIFF
--- a/ethnode/parity.go
+++ b/ethnode/parity.go
@@ -113,6 +113,17 @@ func (n *parityNode) Enode(ctx context.Context) (string, error) {
 	return result, nil
 }
 
+func (n *parityNode) CheckCompatible(ctx context.Context) error {
+	var result interface{}
+	if err := n.client.CallContext(ctx, &result, "parity_enode"); err != nil {
+		return parityWrapModuleError(err, "parity_enode", "parity")
+	}
+	if err := n.client.CallContext(ctx, &result, "parity_addReservedPeer", ""); err != nil {
+		return parityWrapModuleError(err, "parity_addReservedPeer", "parity_set")
+	}
+	return nil
+}
+
 // filterActivePeers filters out any peers that have not completed the
 // handshake yet. In Parity, these are peers without any specified Protocols.
 func filterActivePeers(peers []parityPeerInfo) ([]PeerInfo, error) {
@@ -140,4 +151,17 @@ func parityNodeID(nodeID string) string {
 		return nodeID
 	}
 	return "enode://" + nodeID + "@[::]:30303"
+}
+
+func parityWrapModuleError(err error, method string, module string) error {
+	if err == nil {
+		return nil
+	}
+	if jsonErr, ok := err.(interface{ ErrorCode() int }); ok && jsonErr.ErrorCode() == errCodeMethodNotFound {
+		return CompatibilityError{
+			Err:         err,
+			Explanation: fmt.Sprintf(`Parity RPC method %q is not available, add %q to allowed RPC modules. For example, run parity with the flag --ipc-apis="safe,parity_set"`, method, module),
+		}
+	}
+	return err
 }

--- a/ethnode/rpc.go
+++ b/ethnode/rpc.go
@@ -10,6 +10,26 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+// CompatibilityError is returned when a node fails a compatibility check, such
+// as the version is outdated or it's running in a mode that is not compatible
+// with ethnode.
+type CompatibilityError struct {
+	Err         error
+	Explanation string
+}
+
+func (err CompatibilityError) Error() string {
+	return err.Err.Error()
+}
+
+func (err CompatibilityError) Unwrap() error {
+	return err.Err
+}
+
+func (err CompatibilityError) Explain() string {
+	return err.Explanation
+}
+
 // NodeKind represents the different kinds of node implementations we know about.
 type NodeKind int
 


### PR DESCRIPTION
Fixes #88

Parity 2.5 removed `parity_set` from the default IPC modules. This PR adds a compatibility check and returns a user-friendly error when it's not available. Looks like this:

> agent failed: Method not found
> -> Parity RPC method "parity_addReservedPeer" is not available, add "parity_set" to allowed RPC modules. For example, run parity with the flag --ipc-apis="safe,parity_set"

Additionally, Parity also now requires fully qualified `enode://` strings instead of just nodeIDs for whitelisting, there's a temporary fix that just hardcodes null addresses but I'm not 100% sure it will actually do the desired thing to whitelist the nodeIDs. Opened #90 to fix this later.