### PR TITLE
pool: Add InvalidNode regexp to eject bad nodes

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ type Options struct {
 		AllowOrigin     string `long:"allow-origin" description:"Include Access-Control-Allow-Origin header for CORS."`
 		RestrictNetwork string `long:"restrict-network" description:"Restrict nodes to a single Ethereum network, such as: mainnet, rinkeby, goerli"`
 		MaxRequestHosts int    `long:"max-request-hosts" description:"Maximum number of hosts a node is allowed to request."`
+		InvalidNode     string `long:"invalid-node" description:"Regexp to mark peers as invalid if the node client matches."`
 		Contract        struct {
 			RPC        string `long:"rpc" description:"Path or URL of an Ethereum RPC provider for payment contract operations. Must match the network of the contract."`
 			Addr       string `long:"address" description:"Deployed contract address, prefixed with network name scheme. (Example: \"rinkeby://0xb2f8987986259facdc539ac1745f7a0b395972b1\")"`

--- a/pool.go
+++ b/pool.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -213,6 +214,20 @@ func runPool(options Options) error {
 			return 0, err
 		}
 		return stats.LatestBlockNumber, nil
+	}
+
+	if options.Pool.InvalidNode != "" {
+		re, err := regexp.Compile(options.Pool.InvalidNode)
+		if err != nil {
+			return ErrExplain{err, `Failed to compile --invalid-nodes regular expression`}
+		}
+		p.CheckPeer = func(peer ethnode.PeerInfo) bool {
+			if re.MatchString(peer.Name) {
+				logger.Debugf("Invalid peer matched %q: %s", peer.Name, peer.EnodeURI())
+				return false
+			}
+			return true
+		}
 	}
 
 	handler := &server{


### PR DESCRIPTION
Mark node as invalid if the client string matches a regular expression. Fixes https://github.com/vipnode/vipnode/issues/92

For example:

```
vipnode pool --invalid-node="Parity/v2.5.10"
```

- [ ] Test
- [ ] Is there a better name for this flag?
- [ ] Reject the node when it connects to the pool?